### PR TITLE
Changes to output file names

### DIFF
--- a/src/N_m3u8DL-RE.Common/N_m3u8DL-RE.Common.csproj
+++ b/src/N_m3u8DL-RE.Common/N_m3u8DL-RE.Common.csproj
@@ -12,5 +12,20 @@
   <ItemGroup>
 	  <PackageReference Include="Spectre.Console" Version="0.44.1-preview.0.34" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="Properties\Resources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="Properties\Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
 	
 </Project>

--- a/src/N_m3u8DL-RE.Common/Resource/ResString.cs
+++ b/src/N_m3u8DL-RE.Common/Resource/ResString.cs
@@ -115,6 +115,7 @@ namespace N_m3u8DL_RE.Common.Resource
         public static string noStreamsToDownload { get => GetText("noStreamsToDownload"); }
         public static string newVersionFound { get => GetText("newVersionFound"); }
         public static string processImageSub { get => GetText("processImageSub"); }
+        public static string cmd_skipUpdateCheck { get => GetText("cmd_skipUpdateCheck"); }
 
         private static string GetText(string key)
         {

--- a/src/N_m3u8DL-RE.Common/Resource/StaticText.cs
+++ b/src/N_m3u8DL-RE.Common/Resource/StaticText.cs
@@ -757,7 +757,11 @@ namespace N_m3u8DL_RE.Common.Resource
                 zhTW: "沒有找到需要下載的流",
                 enUS: "No stream found to download"
             ),
-
+            ["cmd_skipUpdateCheck"] = new TextContainer(
+                zhCN: "跳过更新检查",
+                zhTW: "跳过更新检查",
+                enUS: "Skip update check"
+            )
         };
     }
 }

--- a/src/N_m3u8DL-RE/CommandLine/CommandInvoker.cs
+++ b/src/N_m3u8DL-RE/CommandLine/CommandInvoker.cs
@@ -92,6 +92,8 @@ namespace N_m3u8DL_RE.CommandLine
         private readonly static Option<StreamFilter?> DropAudioFilter = new(new string[] { "-da", "--drop-audio" }, description: ResString.cmd_dropAudio, parseArgument: ParseStreamFilter) { ArgumentHelpName = "OPTIONS" };
         private readonly static Option<StreamFilter?> DropSubtitleFilter = new(new string[] { "-ds", "--drop-subtitle" }, description: ResString.cmd_dropSubtitle, parseArgument: ParseStreamFilter) { ArgumentHelpName = "OPTIONS" };
 
+        private readonly static Option<bool> SkipUpdateCheck = new(new string[] { "--skip-update-check" }, description: ResString.cmd_skipUpdateCheck, getDefaultValue: () => true);
+
         /// <summary>
         /// 解析用户代理
         /// </summary>
@@ -380,6 +382,7 @@ namespace N_m3u8DL_RE.CommandLine
                     LogLevel = bindingContext.ParseResult.GetValueForOption(LogLevel),
                     AutoSelect = bindingContext.ParseResult.GetValueForOption(AutoSelect),
                     SkipMerge = bindingContext.ParseResult.GetValueForOption(SkipMerge),
+                    SkipUpdateCheck = bindingContext.ParseResult.GetValueForOption(SkipUpdateCheck),
                     BinaryMerge = bindingContext.ParseResult.GetValueForOption(BinaryMerge),
                     DelAfterDone = bindingContext.ParseResult.GetValueForOption(DelAfterDone),
                     AutoSubtitleFix = bindingContext.ParseResult.GetValueForOption(AutoSubtitleFix),
@@ -488,7 +491,7 @@ namespace N_m3u8DL_RE.CommandLine
                 MuxAfterDone,
                 CustomHLSMethod, CustomHLSKey, CustomHLSIv, UseSystemProxy, CustomProxy, TaskStartAt,
                 LivePerformAsVod, LiveRealTimeMerge, LiveKeepSegments, LivePipeMux, LiveRecordLimit, LiveWaitTime,
-                MuxImports, VideoFilter, AudioFilter, SubtitleFilter, DropVideoFilter, DropAudioFilter, DropSubtitleFilter, MoreHelp
+                MuxImports, VideoFilter, AudioFilter, SubtitleFilter, DropVideoFilter, DropAudioFilter, DropSubtitleFilter, MoreHelp, SkipUpdateCheck
             };
 
             rootCommand.TreatUnmatchedTokensAsErrors = true;

--- a/src/N_m3u8DL-RE/CommandLine/MyOption.cs
+++ b/src/N_m3u8DL-RE/CommandLine/MyOption.cs
@@ -226,5 +226,7 @@ namespace N_m3u8DL_RE.CommandLine
         /// See: <see cref="CommandInvoker.LivePipeMux"/>.
         /// </summary>
         public bool LivePipeMux { get; set; }
+        public bool SkipUpdateCheck { get; set; }
+        
     }
 }

--- a/src/N_m3u8DL-RE/DownloadManager/SimpleLiveRecordManager2.cs
+++ b/src/N_m3u8DL-RE/DownloadManager/SimpleLiveRecordManager2.cs
@@ -514,13 +514,13 @@ namespace N_m3u8DL_RE.DownloadManager
                     var output = Path.Combine(saveDir, saveName + outputExt);
                     if (streamSpec.MediaType == null)
                     {
-                        output = Path.Combine(saveDir, saveName + "_video_" + streamSpec.Codecs + "_" + streamSpec.Resolution + outputExt);
+                        output = Path.Combine(saveDir, saveName + "_video_" + streamSpec.Bandwidth + "_" + streamSpec.Codecs + "_" + streamSpec.Resolution + outputExt);
                     }
 
 
                     if (streamSpec.MediaType == MediaType.AUDIO)
                     {
-                        output = Path.Combine(saveDir, saveName + "_audio_" + streamSpec.Language + "_" + streamSpec.Bandwidth + "_" + streamSpec.Codecs + "_" + streamSpec.Channels + outputExt);
+                        output = Path.Combine(saveDir, saveName + "_audio_" + streamSpec.Bandwidth + "_" + streamSpec.Language + "_" + streamSpec.Codecs + "_" + streamSpec.Channels + outputExt);
                     }
 
                     //移除无效片段

--- a/src/N_m3u8DL-RE/DownloadManager/SimpleLiveRecordManager2.cs
+++ b/src/N_m3u8DL-RE/DownloadManager/SimpleLiveRecordManager2.cs
@@ -512,6 +512,16 @@ namespace N_m3u8DL_RE.DownloadManager
                     }
 
                     var output = Path.Combine(saveDir, saveName + outputExt);
+                    if (streamSpec.MediaType == null)
+                    {
+                        output = Path.Combine(saveDir, saveName + "_video_" + streamSpec.Codecs + "_" + streamSpec.Resolution + outputExt);
+                    }
+
+
+                    if (streamSpec.MediaType == MediaType.AUDIO)
+                    {
+                        output = Path.Combine(saveDir, saveName + "_audio_" + streamSpec.Language + "_" + streamSpec.Bandwidth + "_" + streamSpec.Codecs + "_" + streamSpec.Channels + outputExt);
+                    }
 
                     //移除无效片段
                     var badKeys = FileDic.Where(i => i.Value == null).Select(i => i.Key);

--- a/src/N_m3u8DL-RE/N_m3u8DL-RE.csproj
+++ b/src/N_m3u8DL-RE/N_m3u8DL-RE.csproj
@@ -20,4 +20,19 @@
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Update="Properties\Resources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="Properties\Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+
 </Project>

--- a/src/N_m3u8DL-RE/Program.cs
+++ b/src/N_m3u8DL-RE/Program.cs
@@ -71,7 +71,11 @@ namespace N_m3u8DL_RE
         static async Task DoWorkAsync(MyOption option)
         {
             //检测更新
-            CheckUpdateAsync();
+            if (!option.SkipUpdateCheck)
+                CheckUpdateAsync();
+            else
+                Logger.WarnMarkUp($"[darkorange3_1]Skipping update check due to --skip-update-check not set to false[/]");
+
 
             Logger.LogLevel = option.LogLevel;
             Logger.Info(CommandInvoker.VERSION_INFO);


### PR DESCRIPTION
When pulling similar streams, eg. multiple video, or multiple audio with the same language it would be useful to avoid appending "copy" over and over.

This PR changes the output file name to include relevant streamSpec information such as resolution (for video), codecs, language and channel layouts.

Of course if multiple similar resolutions/bitrate/codec combination exists or similar language/codec/channel/bandwidth, "copy" is still added but that should not normally be the case