### PR TITLE
添加 `--live-pipe-options`用于自定义ffmpeg管道混流参数

### DIFF
--- a/src/N_m3u8DL-RE.Common/Resource/ResString.cs
+++ b/src/N_m3u8DL-RE.Common/Resource/ResString.cs
@@ -81,6 +81,8 @@ namespace N_m3u8DL_RE.Common.Resource
         public static string cmd_customRange { get => GetText("cmd_customRange"); }
         public static string cmd_liveKeepSegments { get => GetText("cmd_liveKeepSegments"); }
         public static string cmd_livePipeMux { get => GetText("cmd_livePipeMux"); }
+        public static string cmd_livePipeOptions { get => GetText("cmd_livePipeOptions"); }
+        public static string cmd_livePipeOptions_more { get => GetText("cmd_livePipeOptions_more"); }
         public static string cmd_liveRecordLimit { get => GetText("cmd_liveRecordLimit"); }
         public static string cmd_taskStartAt { get => GetText("cmd_taskStartAt"); }
         public static string cmd_liveWaitTime { get => GetText("cmd_liveWaitTime"); }

--- a/src/N_m3u8DL-RE.Common/Resource/StaticText.cs
+++ b/src/N_m3u8DL-RE.Common/Resource/StaticText.cs
@@ -406,6 +406,33 @@ namespace N_m3u8DL_RE.Common.Resource
                 zhTW: "錄製直播並開啟即時合併時通過管道+ffmpeg即時混流到TS文件",
                 enUS: "Real-time muxing to TS file through pipeline + ffmpeg (liveRealTimeMerge enabled)"
             ),
+            ["cmd_livePipeOptions"] = new TextContainer
+            (
+                zhCN: "管道+ffmpeg实时混流时传递给ffmpeg的参数. 输入 \"--morehelp live-pipe-options\" 以查看详细信息",
+                zhTW: "管道+ffmpeg實時混流時傳遞給ffmpeg的參數. 輸入 \"--morehelp live-pipe-options\" 以查看詳細訊息",
+                enUS: "Command args passed to ffmpeg when real-time muxing through pipeline + ffmpeg (liveRealTimeMerge enabled). Use \"--morehelp live-pipe-options\" for more details"
+            ),
+            ["cmd_livePipeOptions_more"] = new TextContainer
+            (
+                zhCN: "{INPUTS}将被替换为实际的输入管道.\r\n" +
+                      "{DATE}将被替换为实际的时间.\r\n" +
+                      "上述占位符无需引号包裹\n\r" +
+                      "例如: \r\n\r\n" +
+                      "# 输出为a.ts\r\n"+
+                      "-re {INPUTS} a.ts",
+                zhTW: "{INPUTS}將被替換爲實際的輸入管道.\r\n" +
+                      "{DATE}將被替換爲實際的時間.\r\n" +
+                      "上述佔位符無需引號包裹\n\r\r\n" +
+                      "例如: \r\n" + 
+                      "# 輸出爲a.ts\r\n" +
+                      "-re {INPUTS} a.ts",
+                enUS: "{INPUTS} will be replaced with actual input pipes.\r\n" +
+                      "{DATE} will be replaced with actual time.\r\n" +
+                      "The above placeholders do not need to be wrapped in quotes\r\n\r\n" +
+                      "Example: \r\n" + 
+                      "# output as a.ts\r\n"+
+                      "-re {INPUTS} a.ts"
+            ),
             ["cmd_liveKeepSegments"] = new TextContainer
             (
                 zhCN: "录制直播并开启实时合并时依然保留分片",

--- a/src/N_m3u8DL-RE/CommandLine/CommandInvoker.cs
+++ b/src/N_m3u8DL-RE/CommandLine/CommandInvoker.cs
@@ -18,7 +18,7 @@ namespace N_m3u8DL_RE.CommandLine
 {
     internal partial class CommandInvoker
     {
-        public const string VERSION_INFO = "N_m3u8DL-RE (Beta version) 20230730";
+        public const string VERSION_INFO = "N_m3u8DL-RE (Beta version) 20230731";
 
         [GeneratedRegex("((best|worst)\\d*|all)")]
         private static partial Regex ForStrRegex();
@@ -86,6 +86,7 @@ namespace N_m3u8DL_RE.CommandLine
         private readonly static Option<bool> LiveRealTimeMerge = new(new string[] { "--live-real-time-merge" }, description: ResString.cmd_liveRealTimeMerge, getDefaultValue: () => false);
         private readonly static Option<bool> LiveKeepSegments = new(new string[] { "--live-keep-segments" }, description: ResString.cmd_liveKeepSegments, getDefaultValue: () => true);
         private readonly static Option<bool> LivePipeMux = new(new string[] { "--live-pipe-mux" }, description: ResString.cmd_livePipeMux, getDefaultValue: () => false);
+        private readonly static Option<string?> LivePipeOptions = new(new string[] { "--live-pipe-options" }, description: ResString.cmd_livePipeOptions) { ArgumentHelpName = "OPTIONS" };
         private readonly static Option<TimeSpan?> LiveRecordLimit = new(new string[] { "--live-record-limit" }, description: ResString.cmd_liveRecordLimit, parseArgument: ParseLiveLimit) { ArgumentHelpName = "HH:mm:ss" };
         private readonly static Option<int?> LiveWaitTime = new(new string[] { "--live-wait-time" }, description: ResString.cmd_liveWaitTime) { ArgumentHelpName = "SEC" };
         private readonly static Option<int> LiveTakeCount = new(new string[] { "--live-take-count" }, description: ResString.cmd_liveTakeCount, getDefaultValue: () => 16) { ArgumentHelpName = "NUM" };
@@ -520,6 +521,7 @@ namespace N_m3u8DL_RE.CommandLine
                     TaskStartAt = bindingContext.ParseResult.GetValueForOption(TaskStartAt),
                     LivePerformAsVod = bindingContext.ParseResult.GetValueForOption(LivePerformAsVod),
                     LivePipeMux = bindingContext.ParseResult.GetValueForOption(LivePipeMux),
+                    LivePipeOptions = bindingContext.ParseResult.GetValueForOption(LivePipeOptions),
                     LiveFixVttByAudio = bindingContext.ParseResult.GetValueForOption(LiveFixVttByAudio),
                     UseSystemProxy = bindingContext.ParseResult.GetValueForOption(UseSystemProxy),
                     CustomProxy = bindingContext.ParseResult.GetValueForOption(CustomProxy),
@@ -576,6 +578,7 @@ namespace N_m3u8DL_RE.CommandLine
                 {
                     "mux-after-done" => ResString.cmd_muxAfterDone_more,
                     "mux-import" => ResString.cmd_muxImport_more,
+                    "live-pipe-options" => ResString.cmd_livePipeOptions_more,
                     "select-video" => ResString.cmd_selectVideo_more,
                     "select-audio" => ResString.cmd_selectAudio_more,
                     "select-subtitle" => ResString.cmd_selectSubtitle_more,
@@ -595,7 +598,7 @@ namespace N_m3u8DL_RE.CommandLine
                 MaxSpeed,
                 MuxAfterDone,
                 CustomHLSMethod, CustomHLSKey, CustomHLSIv, UseSystemProxy, CustomProxy, CustomRange, TaskStartAt,
-                LivePerformAsVod, LiveRealTimeMerge, LiveKeepSegments, LivePipeMux, LiveFixVttByAudio, LiveRecordLimit, LiveWaitTime, LiveTakeCount,
+                LivePerformAsVod, LiveRealTimeMerge, LiveKeepSegments, LivePipeMux,LivePipeOptions, LiveFixVttByAudio, LiveRecordLimit, LiveWaitTime, LiveTakeCount,
                 MuxImports, VideoFilter, AudioFilter, SubtitleFilter, DropVideoFilter, DropAudioFilter, DropSubtitleFilter, AdKeywords, MoreHelp
             };
 

--- a/src/N_m3u8DL-RE/CommandLine/MyOption.cs
+++ b/src/N_m3u8DL-RE/CommandLine/MyOption.cs
@@ -239,6 +239,10 @@ namespace N_m3u8DL_RE.CommandLine
         /// </summary>
         public bool LivePipeMux { get; set; }
         /// <summary>
+        /// See: <see cref="CommandInvoker.LivePipeOptions"/>.
+        /// </summary>
+        public string? LivePipeOptions { get; set; }
+        /// <summary>
         /// See: <see cref="CommandInvoker.LiveFixVttByAudio"/>.
         /// </summary>
         public bool LiveFixVttByAudio { get; set; }

--- a/src/N_m3u8DL-RE/DownloadManager/SimpleLiveRecordManager2.cs
+++ b/src/N_m3u8DL-RE/DownloadManager/SimpleLiveRecordManager2.cs
@@ -544,8 +544,7 @@ namespace N_m3u8DL_RE.DownloadManager
                             if (PipeSteamNamesDic.Count == SelectedSteams.Where(x => x.MediaType != MediaType.SUBTITLES).Count()) 
                             {
                                 var names = PipeSteamNamesDic.OrderBy(i => i.Key).Select(k => k.Value).ToArray();
-                                Logger.WarnMarkUp($"{ResString.namedPipeMux} [deepskyblue1]{Path.GetFileName(output).EscapeMarkup()}[/]");
-                                var t = PipeUtil.StartPipeMuxAsync(DownloaderConfig.MyOptions.FFmpegBinaryPath!, names, output);
+                                var t = PipeUtil.StartPipeMuxAsync(DownloaderConfig.MyOptions.FFmpegBinaryPath!, DownloaderConfig.MyOptions.LivePipeOptions, names, output);
                             }
 
                             //Windows only

--- a/src/N_m3u8DL-RE/Program.cs
+++ b/src/N_m3u8DL-RE/Program.cs
@@ -96,6 +96,13 @@ namespace N_m3u8DL_RE
                 throw new ArgumentException("MuxAfterDone disabled, MuxImports not allowed!");
             }
 
+            //LivePipeOptions开启时 LivePipeMux必须开启
+            if (option.LivePipeOptions!=null && !option.LivePipeMux)
+            {
+                Logger.WarnMarkUp("LivePipeOptions detected, forced enable LivePipeMux");
+                option.LivePipeMux = true;
+            }
+
             //LivePipeMux开启时 LiveRealTimeMerge必须开启
             if (option.LivePipeMux && !option.LiveRealTimeMerge)
             {


### PR DESCRIPTION
+ 自定义混流参数，保留从环境变量提取参数的功能 _`live-pipe-options`优先于环境变量_
+ 在存在自定义参数时不输出 `通过命名管道混流到 xxx`
#240 