### PR TITLE
[Fix] fix reading the kid in a multi-DRM file

### DIFF
--- a/src/N_m3u8DL-RE.Parser/Mp4/MP4InitUtil.cs
+++ b/src/N_m3u8DL-RE.Parser/Mp4/MP4InitUtil.cs
@@ -36,7 +36,12 @@ namespace Mp4SubtitleParser
                     if (SYSTEM_ID_WIDEVINE.SequenceEqual(systemId))
                     {
                         var dataSize = box.Reader.ReadUInt32();
-                        info.PSSH = Convert.ToBase64String(box.Reader.ReadBytes((int)dataSize));
+                        var psshData = box.Reader.ReadBytes((int)dataSize);
+                        info.PSSH = Convert.ToBase64String(psshData);
+                        if (info.KID == "00000000000000000000000000000000")
+                        {
+                            info.KID = HexUtil.BytesToHex(psshData[2..18]).ToLower();
+                        }
                     }
                 })
                 .FullBox("encv", MP4Parser.AllData(data => ReadBox(data, info)))


### PR DESCRIPTION
修复在多drm加密场景下读取视频文件kid为000...000的问题，以便在用户提供key的时候解密文件