### PR TITLE
支持只输入KEY未输入KID场景自动补全

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Options:
   --urlprocessor-args <urlprocessor-args>  此字符串将直接传递给URL Processor
   --key <key>                              设置解密密钥, 程序调用mp4decrpyt/shaka-packager进行解密. 格式:
                                            --key KID1:KEY1 --key KID2:KEY2
+                                           对于KEY相同的情况可以直接输入 --key KEY
   --key-text-file <key-text-file>          设置密钥文件,程序将从文件中按KID搜寻KEY以解密.(不建议使用特大文件)
   --decryption-binary-path <PATH>          MP4解密所用工具的全路径, 例如 C:\Tools\mp4decrypt.exe
   --use-shaka-packager                     解密时使用shaka-packager替代mp4decrypt [default: False]

--- a/src/N_m3u8DL-RE.Common/Resource/StaticText.cs
+++ b/src/N_m3u8DL-RE.Common/Resource/StaticText.cs
@@ -252,9 +252,9 @@ namespace N_m3u8DL_RE.Common.Resource
             ),
             ["cmd_keys"] = new TextContainer
             (
-                zhCN: "设置解密密钥, 程序调用mp4decrpyt/shaka-packager进行解密. 格式:\r\n--key KID1:KEY1 --key KID2:KEY2",
-                zhTW: "設置解密密鑰, 程序調用mp4decrpyt/shaka-packager進行解密. 格式:\r\n--key KID1:KEY1 --key KID2:KEY2",
-                enUS: "Pass decryption key(s) to mp4decrypt/shaka-packager. format:\r\n--key KID1:KEY1 --key KID2:KEY2"
+                zhCN: "设置解密密钥, 程序调用mp4decrpyt/shaka-packager进行解密. 格式:\r\n--key KID1:KEY1 --key KID2:KEY2\r\n对于KEY相同的情况可以直接输入 --key KEY",
+                zhTW: "設置解密密鑰, 程序調用mp4decrpyt/shaka-packager進行解密. 格式:\r\n--key KID1:KEY1 --key KID2:KEY2\r\n對於KEY相同的情況可以直接輸入 --key KEY",
+                enUS: "Set decryption key(s) to mp4decrypt/shaka-packager. format:\r\n--key KID1:KEY1 --key KID2:KEY2\r\nor use --key KEY if all tracks share the same key."
             ),
             ["cmd_keyText"] = new TextContainer
             (

--- a/src/N_m3u8DL-RE/Util/MP4DecryptUtil.cs
+++ b/src/N_m3u8DL-RE/Util/MP4DecryptUtil.cs
@@ -14,6 +14,7 @@ namespace N_m3u8DL_RE.Util
         {
             if (keys == null || keys.Length == 0) return false;
 
+            var keyPairs = keys.ToList();
             string? keyPair = null;
             string? trackId = null;
 
@@ -24,17 +25,24 @@ namespace N_m3u8DL_RE.Util
 
             if (!string.IsNullOrEmpty(kid))
             {
-                var test = keys.Where(k => k.StartsWith(kid));
+                var test = keyPairs.Where(k => k.StartsWith(kid));
                 if (test.Any()) keyPair = test.First();
             }
 
-            //Apple
+            // Apple
             if (kid == ZeroKid)
             {
-                keyPair = keys.First();
+                keyPair = keyPairs.First();
                 trackId = "1";
             }
 
+            // user only input key, append kid
+            if (keyPair == null && keyPairs.Count == 1 && !keyPairs.First().Contains(':'))
+            {
+                keyPairs = keyPairs.Select(x => $"{kid}:{x}").ToList();
+                keyPair = keyPairs.First();
+            }
+            
             if (keyPair == null) return false;
 
             //shakaPackager 无法单独解密init文件
@@ -61,11 +69,11 @@ namespace N_m3u8DL_RE.Util
             {
                 if (trackId == null)
                 {
-                    cmd = string.Join(" ", keys.Select(k => $"--key {k}"));
+                    cmd = string.Join(" ", keyPairs.Select(k => $"--key {k}"));
                 }
                 else
                 {
-                    cmd = string.Join(" ", keys.Select(k => $"--key {trackId}:{k.Split(':')[1]}"));
+                    cmd = string.Join(" ", keyPairs.Select(k => $"--key {trackId}:{k.Split(':')[1]}"));
                 }
                 if (init != "")
                 {


### PR DESCRIPTION
用户输入`--key 61ae7c3a37a2978c3c71d7e2f28a5f2a`

解密时程序会自动补齐对应的`KID`, 如`e1db2728eabc91d051b5f5c1b06fc646:61ae7c3a37a2978c3c71d7e2f28a5f2a`

以此来减少部分场景下用户手动计算KID的不便。