### PR TITLE
默认使用ffmpeg进行mp4解密

### DIFF
--- a/src/N_m3u8DL-RE.Common/Resource/ResString.cs
+++ b/src/N_m3u8DL-RE.Common/Resource/ResString.cs
@@ -77,6 +77,7 @@ public class ResString
     public static string cmd_uiLanguage => GetText("cmd_uiLanguage");
     public static string cmd_urlProcessorArgs => GetText("cmd_urlProcessorArgs");
     public static string cmd_useShakaPackager => GetText("cmd_useShakaPackager");
+    public static string cmd_useMp4decrypt => GetText("cmd_useMp4decrypt");
     public static string cmd_concurrentDownload => GetText("cmd_concurrentDownload");
     public static string cmd_useSystemProxy => GetText("cmd_useSystemProxy");
     public static string cmd_customProxy => GetText("cmd_customProxy");

--- a/src/N_m3u8DL-RE.Common/Resource/StaticText.cs
+++ b/src/N_m3u8DL-RE.Common/Resource/StaticText.cs
@@ -270,9 +270,9 @@ internal class StaticText
         ),
         ["cmd_keys"] = new TextContainer
         (
-            zhCN: "设置解密密钥, 程序调用mp4decrpyt/shaka-packager进行解密. 格式:\r\n--key KID1:KEY1 --key KID2:KEY2\r\n对于KEY相同的情况可以直接输入 --key KEY",
-            zhTW: "設置解密密鑰, 程序調用mp4decrpyt/shaka-packager進行解密. 格式:\r\n--key KID1:KEY1 --key KID2:KEY2\r\n對於KEY相同的情況可以直接輸入 --key KEY",
-            enUS: "Set decryption key(s) to mp4decrypt/shaka-packager. format:\r\n--key KID1:KEY1 --key KID2:KEY2\r\nor use --key KEY if all tracks share the same key."
+            zhCN: "设置解密密钥, 程序调用mp4decrpyt/shaka-packager/ffmpeg进行解密. 格式:\r\n--key KID1:KEY1 --key KID2:KEY2\r\n对于KEY相同的情况可以直接输入 --key KEY",
+            zhTW: "設置解密密鑰, 程序調用mp4decrpyt/shaka-packager/ffmpeg進行解密. 格式:\r\n--key KID1:KEY1 --key KID2:KEY2\r\n對於KEY相同的情況可以直接輸入 --key KEY",
+            enUS: "Set decryption key(s) to mp4decrypt/shaka-packager/ffmpeg. format:\r\n--key KID1:KEY1 --key KID2:KEY2\r\nor use --key KEY if all tracks share the same key."
         ),
         ["cmd_keyText"] = new TextContainer
         (
@@ -468,9 +468,15 @@ internal class StaticText
         ),
         ["cmd_useShakaPackager"] = new TextContainer
         (
-            zhCN: "解密时使用shaka-packager替代mp4decrypt",
-            zhTW: "解密時使用shaka-packager替代mp4decrypt",
-            enUS: "Use shaka-packager instead of mp4decrypt to decrypt"
+            zhCN: "解密时使用shaka-packager替代ffmpeg",
+            zhTW: "解密時使用shaka-packager替代ffmpeg",
+            enUS: "Use shaka-packager instead of ffmpeg to decrypt"
+        ),
+        ["cmd_useMp4decrypt"] = new TextContainer
+        (
+            zhCN: "解密时使用mp4decrypt替代ffmpeg",
+            zhTW: "解密時使用mp4decrypt替代ffmpeg",
+            enUS: "Use mp4decrypt instead of ffmpeg to decrypt"
         ),
         ["cmd_concurrentDownload"] = new TextContainer
         (
@@ -744,9 +750,9 @@ internal class StaticText
         ),
         ["realTimeDecMessage"] = new TextContainer
         (
-            zhCN: "启用实时解密时，建议用shaka-packager而非mp4decrypt",
-            zhTW: "啟用即時解密時，建議用shaka-packager而非mp4decrypt",
-            enUS: "When enabling real-time decryption, it is recommended to use shaka-packager instead of mp4decrypt"
+            zhCN: "启用实时解密时，建议用shaka-packager而非mp4decrypt/ffmpeg",
+            zhTW: "啟用即時解密時，建議用shaka-packager而非mp4decrypt/ffmpeg",
+            enUS: "When enabling real-time decryption, it is recommended to use shaka-packager instead of mp4decrypt/ffmpeg"
         ),
         ["liveLimitReached"] = new TextContainer
         (

--- a/src/N_m3u8DL-RE/CommandLine/CommandInvoker.cs
+++ b/src/N_m3u8DL-RE/CommandLine/CommandInvoker.cs
@@ -54,6 +54,7 @@ internal partial class CommandInvoker
     private static readonly Option<bool> AppendUrlParams = new(["--append-url-params"], description: ResString.cmd_appendUrlParams, getDefaultValue: () => false);
     private static readonly Option<bool> MP4RealTimeDecryption = new (["--mp4-real-time-decryption"], description: ResString.cmd_MP4RealTimeDecryption, getDefaultValue: () => false);
     private static readonly Option<bool> UseShakaPackager = new (["--use-shaka-packager"], description: ResString.cmd_useShakaPackager, getDefaultValue: () => false);
+    private static readonly Option<bool> UseMp4Decrypt = new (["--use-mp4decrypt"], description: ResString.cmd_useMp4decrypt, getDefaultValue: () => false);
     private static readonly Option<bool> ForceAnsiConsole = new(["--force-ansi-console"], description: ResString.cmd_forceAnsiConsole);
     private static readonly Option<bool> NoAnsiColor = new(["--no-ansi-color"], description: ResString.cmd_noAnsiColor);
     private static readonly Option<string?> DecryptionBinaryPath = new(["--decryption-binary-path"], description: ResString.cmd_decryptionBinaryPath) { ArgumentHelpName = "PATH" };
@@ -523,6 +524,7 @@ internal partial class CommandInvoker
                 UrlProcessorArgs = bindingContext.ParseResult.GetValueForOption(UrlProcessorArgs),
                 MP4RealTimeDecryption = bindingContext.ParseResult.GetValueForOption(MP4RealTimeDecryption),
                 UseShakaPackager = bindingContext.ParseResult.GetValueForOption(UseShakaPackager),
+                UseMp4Decrypt = bindingContext.ParseResult.GetValueForOption(UseMp4Decrypt),
                 DecryptionBinaryPath = bindingContext.ParseResult.GetValueForOption(DecryptionBinaryPath),
                 FFmpegBinaryPath = bindingContext.ParseResult.GetValueForOption(FFmpegBinaryPath),
                 KeyTextFile = bindingContext.ParseResult.GetValueForOption(KeyTextFile),
@@ -615,7 +617,7 @@ internal partial class CommandInvoker
             Input, TmpDir, SaveDir, SaveName, BaseUrl, ThreadCount, DownloadRetryCount, HttpRequestTimeout, ForceAnsiConsole, NoAnsiColor,AutoSelect, SkipMerge, SkipDownload, CheckSegmentsCount,
             BinaryMerge, UseFFmpegConcatDemuxer, DelAfterDone, NoDateInfo, NoLog, WriteMetaJson, AppendUrlParams, ConcurrentDownload, Headers, /**SavePattern,**/ SubOnly, SubtitleFormat, AutoSubtitleFix,
             FFmpegBinaryPath,
-            LogLevel, UILanguage, UrlProcessorArgs, Keys, KeyTextFile, DecryptionBinaryPath, UseShakaPackager, MP4RealTimeDecryption,
+            LogLevel, UILanguage, UrlProcessorArgs, Keys, KeyTextFile, DecryptionBinaryPath, UseShakaPackager, UseMp4Decrypt, MP4RealTimeDecryption,
             MaxSpeed,
             MuxAfterDone,
             CustomHLSMethod, CustomHLSKey, CustomHLSIv, UseSystemProxy, CustomProxy, CustomRange, TaskStartAt,

--- a/src/N_m3u8DL-RE/CommandLine/MyOption.cs
+++ b/src/N_m3u8DL-RE/CommandLine/MyOption.cs
@@ -141,6 +141,10 @@ internal class MyOption
     /// </summary>
     public bool UseShakaPackager { get; set; }
     /// <summary>
+    /// See: <see cref="CommandInvoker.UseMp4Decrypt"/>.
+    /// </summary>
+    public bool UseMp4Decrypt { get; set; }
+    /// <summary>
     /// See: <see cref="CommandInvoker.MuxAfterDone"/>.
     /// </summary>
     public bool MuxAfterDone { get; set; }
@@ -266,4 +270,13 @@ internal class MyOption
     /// See: <see cref="CommandInvoker.LiveFixVttByAudio"/>.
     /// </summary>
     public bool LiveFixVttByAudio { get; set; }
+    
+    public DecryptEngine GetDecryptEngine()
+    {
+        if (UseShakaPackager)
+            return DecryptEngine.SHAKA_PACKAGE;
+        if (UseMp4Decrypt)
+            return DecryptEngine.MP4DECRYPT;
+        return DecryptEngine.FFMPEG;
+    }
 }

--- a/src/N_m3u8DL-RE/Enum/DecryptEngine.cs
+++ b/src/N_m3u8DL-RE/Enum/DecryptEngine.cs
@@ -1,0 +1,8 @@
+namespace N_m3u8DL_RE.Enum;
+
+internal enum DecryptEngine
+{
+    MP4DECRYPT,
+    SHAKA_PACKAGE,
+    FFMPEG,
+}

--- a/src/N_m3u8DL-RE/Program.cs
+++ b/src/N_m3u8DL-RE/Program.cs
@@ -105,10 +105,14 @@ internal class Program
         }
 
         // 检查互斥的选项
-
         if (option is { MuxAfterDone: false, MuxImports.Count: > 0 })
         {
             throw new ArgumentException("MuxAfterDone disabled, MuxImports not allowed!");
+        }
+        
+        if (option is { UseShakaPackager: true, UseMp4Decrypt: true })
+        {
+            throw new ArgumentException("UseShakaPackager and UseMp4Decrypt cannot be enabled simultaneously!");
         }
 
         // LivePipeMux开启时 LiveRealTimeMerge必须开启
@@ -154,12 +158,16 @@ internal class Program
                     option.DecryptionBinaryPath = file ?? file2 ?? file3 ?? file4;
                     Logger.Extra($"shaka-packager => {option.DecryptionBinaryPath}");
                 }
-                else
+                else if (option.UseMp4Decrypt)
                 {
                     var file = GlobalUtil.FindExecutable("mp4decrypt");
                     if (file == null) throw new FileNotFoundException("mp4decrypt not found!");
                     option.DecryptionBinaryPath = file;
                     Logger.Extra($"mp4decrypt => {option.DecryptionBinaryPath}");
+                }
+                else
+                {
+                    option.DecryptionBinaryPath = option.FFmpegBinaryPath;
                 }
             }
             else if (!File.Exists(option.DecryptionBinaryPath))

--- a/src/N_m3u8DL-RE/Util/DownloadUtil.cs
+++ b/src/N_m3u8DL-RE/Util/DownloadUtil.cs
@@ -24,7 +24,7 @@ internal static class DownloadUtil
         else
         {
             var buffer = new byte[expect];
-            await inputStream.ReadAsync(buffer);
+            _ = await inputStream.ReadAsync(buffer);
             await outputStream.WriteAsync(buffer, 0, buffer.Length);
             speedContainer.Add(buffer.Length);
         }


### PR DESCRIPTION
破坏性修改

鉴于mp4decrypt对中文支持程度不佳，且官方没有修改意愿，本程序的默认解密程序已经切换到ffmpeg。

软件同时保留了对于mp4decrypt的支持，你可以新的选项：`--use-mp4decrypt`

---
Breaking Change

Due to the poor support for Chinese in mp4decrypt and the lack of intention from the official team to make changes, the default decryption program in this software has been switched to ffmpeg.

The software also retains support for mp4decrypt. You can use the new option: `--use-mp4decrypt`.