### PR TITLE
解决mp4decrypt对中文文件名支持不佳问题

### DIFF
--- a/src/N_m3u8DL-RE.Common/Resource/ResString.cs
+++ b/src/N_m3u8DL-RE.Common/Resource/ResString.cs
@@ -1,6 +1,6 @@
 ﻿namespace N_m3u8DL_RE.Common.Resource;
 
-public class ResString
+public static class ResString
 {
     public static string CurrentLoc = "en-US";
 
@@ -125,6 +125,7 @@ public class ResString
     public static string promptTitle => GetText("promptTitle");
     public static string readingInfo => GetText("readingInfo");
     public static string searchKey => GetText("searchKey");
+    public static string decryptionFailed => GetText("decryptionFailed");
     public static string segmentCountCheckNotPass => GetText("segmentCountCheckNotPass");
     public static string selectedStream => GetText("selectedStream");
     public static string startDownloading => GetText("startDownloading");

--- a/src/N_m3u8DL-RE.Common/Resource/StaticText.cs
+++ b/src/N_m3u8DL-RE.Common/Resource/StaticText.cs
@@ -910,6 +910,12 @@ internal class StaticText
             zhTW: "正在嘗試從文本文件搜尋KEY...",
             enUS: "Trying to search for KEY from text file..."
         ),
+        ["decryptionFailed"] = new TextContainer
+        (
+            zhCN: "解密失败",
+            zhTW: "解密失敗",
+            enUS: "Decryption failed"
+        ),
         ["segmentCountCheckNotPass"] = new TextContainer
         (
             zhCN: "分片数量校验不通过, 共{}个,已下载{}.",

--- a/src/N_m3u8DL-RE/CommandLine/CommandInvoker.cs
+++ b/src/N_m3u8DL-RE/CommandLine/CommandInvoker.cs
@@ -17,7 +17,7 @@ namespace N_m3u8DL_RE.CommandLine;
 
 internal partial class CommandInvoker
 {
-    public const string VERSION_INFO = "N_m3u8DL-RE (Beta version) 20241129";
+    public const string VERSION_INFO = "N_m3u8DL-RE (Beta version) 20241130";
 
     [GeneratedRegex("((best|worst)\\d*|all)")]
     private static partial Regex ForStrRegex();

--- a/src/N_m3u8DL-RE/Util/MP4DecryptUtil.cs
+++ b/src/N_m3u8DL-RE/Util/MP4DecryptUtil.cs
@@ -17,6 +17,9 @@ internal static class MP4DecryptUtil
         var keyPairs = keys.ToList();
         string? keyPair = null;
         string? trackId = null;
+        string? tmpEncFile = null;
+        string? tmpDecFile = null;
+        string? workDir = null;
 
         if (isMultiDRM)
         {
@@ -79,7 +82,12 @@ internal static class MP4DecryptUtil
             {
                 cmd += $" --fragments-info \"{init}\" ";
             }
-            cmd += $" \"{source}\" \"{dest}\"";
+            // 解决mp4decrypt中文问题 切换到源文件所在目录并改名再解密
+            workDir = Path.GetDirectoryName(source)!;
+            tmpEncFile = Path.Combine(workDir, $"{Guid.NewGuid()}{Path.GetExtension(source)}");
+            tmpDecFile = Path.Combine(workDir, $"{Path.GetFileNameWithoutExtension(tmpEncFile)}_dec{Path.GetExtension(tmpEncFile)}");
+            File.Move(source, tmpEncFile);
+            cmd += $" \"{Path.GetFileName(tmpEncFile)}\" \"{Path.GetFileName(tmpDecFile)}\"";
         }
         else
         {
@@ -95,30 +103,41 @@ internal static class MP4DecryptUtil
             cmd = $"-loglevel error -nostdin -decryption_key {keyPair.Split(':')[1]} -i \"{enc}\" -c copy \"{dest}\"";
         }
 
-        await RunCommandAsync(bin, cmd);
+        var isSuccess = await RunCommandAsync(bin, cmd, workDir);
+        
+        // mp4decrypt 还原文件改名操作
+        if (workDir is not null)
+        {
+            File.Move(tmpEncFile!, source);
+            File.Move(tmpDecFile!, dest);
+        }
 
-        if (File.Exists(dest) && new FileInfo(dest).Length > 0)
+        if (isSuccess)
         {
             if (tmpFile != "" && File.Exists(tmpFile)) File.Delete(tmpFile);
             return true;
         }
-
+        
+        Logger.Error(ResString.decryptionFailed);
         return false;
     }
 
-    private static async Task RunCommandAsync(string name, string arg)
+    private static async Task<bool> RunCommandAsync(string name, string arg, string? workDir = null)
     {
         Logger.DebugMarkUp($"FileName: {name}");
         Logger.DebugMarkUp($"Arguments: {arg}");
-        await Process.Start(new ProcessStartInfo()
+        var process = Process.Start(new ProcessStartInfo()
         {
             FileName = name,
             Arguments = arg,
             // RedirectStandardOutput = true,
             // RedirectStandardError = true,
             CreateNoWindow = true,
-            UseShellExecute = false
-        })!.WaitForExitAsync();
+            UseShellExecute = false,
+            WorkingDirectory = workDir
+        });
+        await process!.WaitForExitAsync();
+        return process.ExitCode == 0;
     }
 
     /// <summary>


### PR DESCRIPTION
思路：

修改调用文件时的工作目录，然后将加密文件改名为随机的不带特殊字符的文件名，然后进行正常解密，解密完再恢复原始文件名。

---
Idea:

Modify the working directory when calling the file, then rename the encrypted file to a random name without special characters. Proceed with normal decryption, and after decryption, restore the original file name.

---

Fix #233 #507 