### PR TITLE
Detect end of livestream and stop recording

### DIFF
--- a/src/N_m3u8DL-RE.Common/Resource/ResString.cs
+++ b/src/N_m3u8DL-RE.Common/Resource/ResString.cs
@@ -97,6 +97,7 @@ public static class ResString
     public static string liveLimit => GetText("liveLimit");
     public static string realTimeDecMessage => GetText("realTimeDecMessage");
     public static string liveLimitReached => GetText("liveLimitReached");
+    public static string liveFinished => GetText("liveFinished");
     public static string saveName => GetText("saveName");
     public static string taskStartAt => GetText("taskStartAt");
     public static string namedPipeCreated => GetText("namedPipeCreated");

--- a/src/N_m3u8DL-RE.Common/Resource/StaticText.cs
+++ b/src/N_m3u8DL-RE.Common/Resource/StaticText.cs
@@ -754,6 +754,12 @@ internal static class StaticText
             zhTW: "到達直播錄製上限，即將停止錄製",
             enUS: "Live recording limit reached, will stop recording soon"
         ),
+        ["liveFinished"] = new TextContainer
+        (
+            zhCN: "直播已结束，即将停止录制",
+            zhTW: "直播已結束，即將停止錄製",
+            enUS: "Livestream seems to have ended, will stop recording"
+        ),
         ["saveName"] = new TextContainer
         (
             zhCN: "保存文件名: ",

--- a/src/N_m3u8DL-RE.Parser/Extractor/HLSExtractor.cs
+++ b/src/N_m3u8DL-RE.Parser/Extractor/HLSExtractor.cs
@@ -547,10 +547,14 @@ internal class HLSExtractor : IExtractor
 
             var newPlaylist = await ParseListAsync();
             if (lists[i].Playlist?.MediaInit != null)
+            {
                 lists[i].Playlist!.MediaParts = newPlaylist.MediaParts; // 不更新init
+                lists[i].Playlist!.IsLive = newPlaylist.IsLive;
+            }
             else
+            {
                 lists[i].Playlist = newPlaylist;
-
+            }
             if (lists[i].MediaType == MediaType.SUBTITLES)
             {
                 var a = lists[i].Playlist!.MediaParts.Any(p => p.MediaSegments.Any(m => m.Url.Contains(".ttml")));


### PR DESCRIPTION
This fixes #594.

I tested it with Chzzk and Weverse and it worked. It might not cover some cases (for example, if the server doesn't correctly mark the end of the stream it will never end, which could be solved by have some kind of time limit on no new segments).

In any case, it's an improvement over the current implementation (which basically keeps refreshing forever until the m3u8 expires, which could be hours later or never).