### PR TITLE
Skip current producer task when MediaParts is empty, in order to retry in the next fetch

### DIFF
--- a/src/N_m3u8DL-RE/DownloadManager/SimpleLiveRecordManager2.cs
+++ b/src/N_m3u8DL-RE/DownloadManager/SimpleLiveRecordManager2.cs
@@ -656,6 +656,10 @@ internal class SimpleLiveRecordManager2
                 if (RecordLimitReachedDic[task.Id])
                     return;
 
+                // 如果 MediaParts 为空，播放列表可能已损坏，跳过并下次重试
+                if (streamSpec.Playlist!.MediaParts.Count == 0)
+                    return;
+                
                 var allHasDatetime = streamSpec.Playlist!.MediaParts[0].MediaSegments.All(s => s.DateTime != null);
                 if (!SamePathDic.ContainsKey(task.Id))
                 {


### PR DESCRIPTION
I have had this happen for some livestreams (on Chzzk). Sometimes the server sends a slightly malformed playlist and the extractor is not able to parse it correctly. What currently happens is that the task crashes silently on trying to access MediaParts[0], which leaves the consumer task waiting for input forever.

This change attemps to remedy this by ignoring the malformed playlist and trying on the next fetch.