### PR TITLE
Fix stuck when ffmpeg error in live pipe mux

### DIFF
--- a/src/N_m3u8DL-RE/DownloadManager/SimpleLiveRecordManager2.cs
+++ b/src/N_m3u8DL-RE/DownloadManager/SimpleLiveRecordManager2.cs
@@ -537,6 +537,15 @@ internal class SimpleLiveRecordManager2
                             var names = PipeSteamNamesDic.OrderBy(i => i.Key).Select(k => k.Value).ToArray();
                             Logger.WarnMarkUp($"{ResString.namedPipeMux} [deepskyblue1]{Path.GetFileName(output).EscapeMarkup()}[/]");
                             var t = PipeUtil.StartPipeMuxAsync(DownloaderConfig.MyOptions.FFmpegBinaryPath!, names, output);
+                            t.ContinueWith(task =>
+                            {
+                                if (task.IsFaulted)
+                                {
+                                    Logger.ErrorMarkUp($"Pipe mux error: {task.Exception!.InnerException!.Message}, exiting...");
+                                    Environment.Exit(1);
+                                }
+                            });
+
                         }
 
                         // Windows only

--- a/src/N_m3u8DL-RE/Util/PipeUtil.cs
+++ b/src/N_m3u8DL-RE/Util/PipeUtil.cs
@@ -50,7 +50,7 @@ internal static class PipeUtil
         p.Dispose();
         if (!exitNormally)
         {
-            throw new Exception("FFmpeg pipe muxer exit with non-zero exit code");
+            throw new Exception("FFmpeg pipe mux exit with non-zero exit code");
         }
         return exitNormally;
     }

--- a/src/N_m3u8DL-RE/Util/PipeUtil.cs
+++ b/src/N_m3u8DL-RE/Util/PipeUtil.cs
@@ -43,6 +43,20 @@ internal static class PipeUtil
 
     public static bool StartPipeMux(string binary, string[] pipeNames, string outputPath)
     {
+        Process p = CreatePipeMux(binary, pipeNames, outputPath);
+        p.Start();
+        p.WaitForExit();
+        bool exitNormally = p.ExitCode == 0;
+        p.Dispose();
+        if (!exitNormally)
+        {
+            throw new Exception("FFmpeg pipe muxer exit with non-zero exit code");
+        }
+        return exitNormally;
+    }
+
+    public static Process CreatePipeMux(string binary, string[] pipeNames, string outputPath)
+    {
         string dateString = DateTime.Now.ToString("o");
         StringBuilder command = new StringBuilder("-y -fflags +genpts -loglevel quiet ");
 
@@ -86,7 +100,7 @@ internal static class PipeUtil
             command.Append($" -f mpegts -shortest \"{outputPath}\"");
         }
 
-        using var p = new Process();
+        var p = new Process();
         p.StartInfo = new ProcessStartInfo()
         {
             WorkingDirectory = Environment.CurrentDirectory,
@@ -96,9 +110,6 @@ internal static class PipeUtil
             UseShellExecute = false
         };
         // p.StartInfo.Environment.Add("FFREPORT", "file=ffreport.log:level=42");
-        p.Start();
-        p.WaitForExit();
-
-        return p.ExitCode == 0;
+        return p;
     }
 }


### PR DESCRIPTION
Fix the stuck issue mentioned in #468 

When ffmpeg exit abnormally, error happend for using **`RE_LIVE_PIPE_OPTIONS`** with pipe to ffmepg muxer.

In Windows, beacause of  **`NamedPipeServerStream`**, the program will exited by C# throwing Exception.
In linux, the **`Process`** may not handle the none-zero exit code, so the main thread is still running.

I‘m not an expert at C#, I tryied to log the error message from ffmpeg process, but failed.

---------------

### Command
```bash
RE_LIVE_PIPE_OPTIONS="-c copy -f flv rtmp://${url}"  N_m3u8DL-RE "url" --live-real-time-merge --live-pipe-mux
```

### Windows pipe error to ffmpeg
```bash
ERROR: System.IO.IOException: Pipe is broken.
   at System.IO.Pipes.PipeStream.Write(Byte[] buffer, Int32 offset, Int32 count)
   at System.IO.Stream.CopyTo(Stream destination, Int32 bufferSize)
   at N_m3u8DL_RE.DownloadManager.SimpleLiveRecordManager2.RecordStreamAsync(StreamSpec streamSpec, ProgressTask task, SpeedContainer speedContainer, BufferBlock`1 source) in N_m3u8DL-RE\src\N_m3u8DL-RE\DownloadManager\SimpleLiveRecordManager2.cs:line 564
   at N_m3u8DL_RE.DownloadManager.SimpleLiveRecordManager2.<>c__DisplayClass28_0.<<StartRecordAsync>b__8>d.MoveNext() in N_m3u8DL-RE\src\N_m3u8DL-RE\DownloadManager\SimpleLiveRecordManager2.cs:line 854
--- End of stack trace from previous location ---
   at System.Threading.Tasks.Parallel.<>c__53`1.<<ForEachAsync>b__53_0>d.MoveNext()
--- End of stack trace from previous location ---
   at N_m3u8DL_RE.DownloadManager.SimpleLiveRecordManager2.<>c__DisplayClass28_0.<<StartRecordAsync>b__1>d.MoveNext() in N_m3u8DL-RE\src\N_m3u8DL-RE\DownloadManager\SimpleLiveRecordManager2.cs:line 850
--- End of stack trace from previous location ---
   at Spectre.Console.Progress.<>c__DisplayClass31_0.<<StartAsync>b__0>d.MoveNext() in /_/src/Spectre.Console/Live/Progress/Progress.cs:line 103
--- End of stack trace from previous location ---
   at Spectre.Console.Progress.<>c__DisplayClass32_0`1.<<StartAsync>b__0>d.MoveNext() in /_/src/Spectre.Console/Live/Progress/Progress.cs:line 138
--- End of stack trace from previous location ---
   at Spectre.Console.Internal.DefaultExclusivityMode.RunAsync[T](Func`1 func) in /_/src/Spectre.Console/Internal/DefaultExclusivityMode.cs:line 40
   at Spectre.Console.Progress.StartAsync[T](Func`2 action) in /_/src/Spectre.Console/Live/Progress/Progress.cs:line 121
   at Spectre.Console.Progress.StartAsync(Func`2 action) in /_/src/Spectre.Console/Live/Progress/Progress.cs:line 101
   at N_m3u8DL_RE.DownloadManager.SimpleLiveRecordManager2.StartRecordAsync() in N_m3u8DL-RE\src\N_m3u8DL-RE\DownloadManager\SimpleLiveRecordManager2.cs:line 811
   at N_m3u8DL_RE.Program.DoWorkAsync(MyOption option) in N_m3u8DL-RE\src\N_m3u8DL-RE\Program.cs:line 410
   at N_m3u8DL_RE.CommandLine.CommandInvoker.<>c__DisplayClass81_0.<<InvokeArgs>b__0>d.MoveNext() in N_m3u8DL-RE\src\N_m3u8DL-RE\CommandLine\CommandInvoker.cs:line 628
--- End of stack trace from previous location ---
   at System.CommandLine.Invocation.AnonymousCommandHandler.InvokeAsync(InvocationContext context)
   at System.CommandLine.Invocation.InvocationPipeline.<>c__DisplayClass4_0.<<BuildInvocationChain>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass17_0.<<UseParseErrorReporting>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass12_0.<<UseHelp>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass22_0.<<UseVersionOption>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass19_0.<<UseTypoCorrections>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<UseSuggestDirective>b__18_0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass16_0.<<UseParseDirective>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<RegisterWithDotnetSuggest>b__5_0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass8_0.<<UseExceptionHandler>b__0>d.MoveNext()
```