### PR TITLE
Period Stream Filter & Bugfix Inverse Logic

### DIFF
--- a/src/N_m3u8DL-RE.Common/Entity/StreamSpec.cs
+++ b/src/N_m3u8DL-RE.Common/Entity/StreamSpec.cs
@@ -148,19 +148,19 @@ public class StreamSpec
         if (MediaType == Enum.MediaType.AUDIO)
         {
             prefixStr = $"[deepskyblue3]Aud[/] {encStr}";
-            var d = $"{GroupId} | {(Bandwidth != null ? (Bandwidth / 1000) + " Kbps" : "")} | {Name} | {Codecs} | {Language} | {(Channels != null ? Channels + "CH" : "")} | {segmentsCountStr} | {Role}";
+            var d = $"{GroupId} | {(Bandwidth != null ? (Bandwidth / 1000) + " Kbps" : "")} | {Name} | {(PeriodId != null ? PeriodId : "")} | {Codecs} | {Language} | {(Channels != null ? Channels + "CH" : "")} | {segmentsCountStr} | {Role}";
             returnStr = d.EscapeMarkup();
         }
         else if (MediaType == Enum.MediaType.SUBTITLES)
         {
             prefixStr = $"[deepskyblue3_1]Sub[/] {encStr}";
-            var d = $"{GroupId} | {Language} | {Name} | {Codecs} | {Characteristics} | {segmentsCountStr} | {Role}";
+            var d = $"{GroupId} | {Language} | {Name} | {(PeriodId != null ? PeriodId : "")} | {Codecs} | {Characteristics} | {segmentsCountStr} | {Role}";
             returnStr = d.EscapeMarkup();
         }
         else
         {
             prefixStr = $"[aqua]Vid[/] {encStr}";
-            var d = $"{Resolution} | {Bandwidth / 1000} Kbps | {GroupId} | {FrameRate} | {Codecs} | {VideoRange} | {segmentsCountStr} | {Role}";
+            var d = $"{Resolution} | {Bandwidth / 1000} Kbps | {GroupId} | {(PeriodId != null ? PeriodId : "")} | {FrameRate} | {Codecs} | {VideoRange} | {segmentsCountStr} | {Role}";
             returnStr = d.EscapeMarkup();
         }
 

--- a/src/N_m3u8DL-RE/CommandLine/CommandInvoker.cs
+++ b/src/N_m3u8DL-RE/CommandLine/CommandInvoker.cs
@@ -382,6 +382,10 @@ internal static partial class CommandInvoker
         if (!string.IsNullOrEmpty(url))
             streamFilter.UrlReg = new Regex(url);
 
+        var period = p.GetValue("period");
+        if (!string.IsNullOrEmpty(period))
+            streamFilter.PeriodReg = new Regex(period);
+
         var segsMin = p.GetValue("segsMin");
         if (!string.IsNullOrEmpty(segsMin))
             streamFilter.SegmentsMinCount = long.Parse(segsMin);

--- a/src/N_m3u8DL-RE/Entity/StreamFilter.cs
+++ b/src/N_m3u8DL-RE/Entity/StreamFilter.cs
@@ -15,6 +15,7 @@ public class StreamFilter
     public Regex? ChannelsReg { get; set; }
     public Regex? VideoRangeReg { get; set; }
     public Regex? UrlReg { get; set; }
+    public Regex? PeriodReg { get; set; }
     public long? SegmentsMinCount { get; set; }
     public long? SegmentsMaxCount { get; set; }
     public double? PlaylistMinDur {  get; set; }
@@ -38,6 +39,7 @@ public class StreamFilter
         if (ChannelsReg != null) sb.Append($"ChannelsReg: {ChannelsReg} ");
         if (VideoRangeReg != null) sb.Append($"VideoRangeReg: {VideoRangeReg} ");
         if (UrlReg != null) sb.Append($"UrlReg: {UrlReg} ");
+        if (PeriodReg != null) sb.Append($"PeriodReg: {PeriodReg} ");
         if (SegmentsMinCount != null) sb.Append($"SegmentsMinCount: {SegmentsMinCount} ");
         if (SegmentsMaxCount != null) sb.Append($"SegmentsMaxCount: {SegmentsMaxCount} ");
         if (PlaylistMinDur != null) sb.Append($"PlaylistMinDur: {PlaylistMinDur} ");

--- a/src/N_m3u8DL-RE/Util/FilterUtil.cs
+++ b/src/N_m3u8DL-RE/Util/FilterUtil.cs
@@ -33,6 +33,8 @@ public static class FilterUtil
             inputs = inputs.Where(i => i.VideoRange != null && filter.VideoRangeReg.IsMatch(i.VideoRange));
         if (filter.UrlReg != null)
             inputs = inputs.Where(i => i.Url != null && filter.UrlReg.IsMatch(i.Url));
+        if (filter.PeriodReg != null)
+            inputs = inputs.Where(i => i.PeriodId != null && filter.PeriodReg.IsMatch(i.PeriodId));
         if (filter.SegmentsMaxCount != null && inputs.All(i => i.SegmentsCount > 0)) 
             inputs = inputs.Where(i => i.SegmentsCount < filter.SegmentsMaxCount);
         if (filter.SegmentsMinCount != null && inputs.All(i => i.SegmentsCount > 0))

--- a/src/N_m3u8DL-RE/Util/FilterUtil.cs
+++ b/src/N_m3u8DL-RE/Util/FilterUtil.cs
@@ -70,9 +70,56 @@ public static class FilterUtil
         if (filter == null) return [..lists];
 
         var inputs = lists.Where(_ => true);
-        var selected = DoFilterKeep(lists, filter);
 
-        inputs = inputs.Where(i => selected.All(s => s.ToString() != i.ToString()));
+        //var selected = DoFilterKeep(lists, filter);
+        //inputs = inputs.Where(i => selected.All(s => s.ToString() != i.ToString()));
+
+        if (filter.GroupIdReg != null)
+            inputs = inputs.Where(i => i.GroupId == null || !filter.GroupIdReg.IsMatch(i.GroupId));
+        if (filter.LanguageReg != null)
+            inputs = inputs.Where(i => i.Language == null || !filter.LanguageReg.IsMatch(i.Language));
+        if (filter.NameReg != null)
+            inputs = inputs.Where(i => i.Name == null || !filter.NameReg.IsMatch(i.Name));
+        if (filter.CodecsReg != null)
+            inputs = inputs.Where(i => i.Codecs == null || !filter.CodecsReg.IsMatch(i.Codecs));
+        if (filter.ResolutionReg != null)
+            inputs = inputs.Where(i => i.Resolution == null || !filter.ResolutionReg.IsMatch(i.Resolution));
+        if (filter.FrameRateReg != null)
+            inputs = inputs.Where(i => i.FrameRate == null || !filter.FrameRateReg.IsMatch($"{i.FrameRate}"));
+        if (filter.ChannelsReg != null)
+            inputs = inputs.Where(i => i.Channels == null || !filter.ChannelsReg.IsMatch(i.Channels));
+        if (filter.VideoRangeReg != null)
+            inputs = inputs.Where(i => i.VideoRange == null || !filter.VideoRangeReg.IsMatch(i.VideoRange));
+        if (filter.UrlReg != null)
+            inputs = inputs.Where(i => i.Url == null || !filter.UrlReg.IsMatch(i.Url));
+        if (filter.PeriodReg != null)
+            inputs = inputs.Where(i => i.PeriodId == null || !filter.PeriodReg.IsMatch(i.PeriodId));
+        if (filter.SegmentsMaxCount != null && inputs.All(i => i.SegmentsCount > 0))
+            inputs = inputs.Where(i => i.SegmentsCount >= filter.SegmentsMaxCount);
+        if (filter.SegmentsMinCount != null && inputs.All(i => i.SegmentsCount > 0))
+            inputs = inputs.Where(i => i.SegmentsCount <= filter.SegmentsMinCount);
+        if (filter.PlaylistMinDur != null)
+            inputs = inputs.Where(i => i.Playlist?.TotalDuration <= filter.PlaylistMinDur);
+        if (filter.PlaylistMaxDur != null)
+            inputs = inputs.Where(i => i.Playlist?.TotalDuration >= filter.PlaylistMaxDur);
+        if (filter.BandwidthMin != null)
+            inputs = inputs.Where(i => i.Bandwidth < filter.BandwidthMin);
+        if (filter.BandwidthMax != null)
+            inputs = inputs.Where(i => i.Bandwidth > filter.BandwidthMax);
+        if (filter.Role.HasValue)
+            inputs = inputs.Where(i => i.Role != filter.Role);
+
+        var bestNumberStr = filter.For.Replace("best", "");
+        var worstNumberStr = filter.For.Replace("worst", "");
+
+        if (filter.For == "best" && inputs.Any())
+            inputs = inputs.Take(1).ToList();
+        else if (filter.For == "worst" && inputs.Any())
+            inputs = inputs.TakeLast(1).ToList();
+        else if (int.TryParse(bestNumberStr, out int bestNumber) && inputs.Any())
+            inputs = inputs.Take(bestNumber).ToList();
+        else if (int.TryParse(worstNumberStr, out int worstNumber) && inputs.Any())
+            inputs = inputs.TakeLast(worstNumber).ToList();
 
         return inputs.ToList();
     }


### PR DESCRIPTION
I've added an option to drop streams based on the period name, this can be useful to drop ads which got injected into the mpd.
Sample: `<Period id="ad-bumper-0-0" duration="PT5.005S" start="PT0.000S">`

While adding this option I've noticed a bug - the dropping of streams isn't working properly. I like the approach how it was initially designed to select the streams using `DoFilterKeep()` and then inversing the selection, however this wont work if I specify multiple criteria's. 

In my case: `--drop-audio role=Description:period=ad-bumper:for=all`
The logic is searching for streams with role "Description" AND period "ad-bumper". It wont find any streams and ends up doing nothing.

I copied the `DoFilterKeep()` into `DoFilterDrop()` and inversed now every condition. A bit more code but works now correct.