### PR TITLE
Fixed Regex match for subtitles with newline

### DIFF
--- a/src/N_m3u8DL-RE.Parser/Mp4/MP4TtmlUtil.cs
+++ b/src/N_m3u8DL-RE.Parser/Mp4/MP4TtmlUtil.cs
@@ -32,7 +32,7 @@ public static partial class MP4TtmlUtil
 {
     [GeneratedRegex(" \\w+:\\w+=\\\"[^\\\"]*\\\"")]
     private static partial Regex AttrRegex();
-    [GeneratedRegex("<p.*?>(.+?)<\\/p>")]
+    [GeneratedRegex("<p.*?>((.|\n)+?)<\\/p>")]
     private static partial Regex LabelFixRegex();
     [GeneratedRegex(@"\<tt[\s\S]*?\<\/tt\>")]
     private static partial Regex MultiElementsFixRegex();


### PR DESCRIPTION
If subtitle XML had \n in it then the "xmlContentFix" wouldn't work, so I updated the Regex to include \n in it.

I had issues with subtitles failing to parse due to invalid characters "&" in them.
The function `private static WebVttSub ExtractSub(List<string> xmls, long baseTimestamp)` would fail.
I noticed that the Regex didn't match the contents when the XML had NewLine, so the xmlContentFix try/catch would be completely skipped.
Adding NewLine handling fixed this issue.