### PR TITLE
优化URL响应类型识别

### DIFF
--- a/src/N_m3u8DL-RE.Common/Resource/ResString.cs
+++ b/src/N_m3u8DL-RE.Common/Resource/ResString.cs
@@ -5,6 +5,7 @@ public static class ResString
     public static string CurrentLoc { get; set; } = "en-US";
 
     public static readonly string ReLiveTs = "<RE_LIVE_TS>";
+    public static readonly string ReBinaryData = "<RE_BINARY_DATA>";
     public static string singleFileRealtimeDecryptWarn => GetText("singleFileRealtimeDecryptWarn");
     public static string singleFileSplitWarn => GetText("singleFileSplitWarn");
     public static string customRangeWarn => GetText("customRangeWarn");
@@ -122,6 +123,7 @@ public static class ResString
     public static string matchMSS => GetText("matchMSS");
     public static string matchTS => GetText("matchTS");
     public static string matchHLS => GetText("matchHLS");
+    public static string matchBinaryData => GetText("matchBinaryData");
     public static string notSupported => GetText("notSupported");
     public static string parsingStream => GetText("parsingStream");
     public static string promptChoiceText => GetText("promptChoiceText");

--- a/src/N_m3u8DL-RE.Common/Resource/StaticText.cs
+++ b/src/N_m3u8DL-RE.Common/Resource/StaticText.cs
@@ -892,6 +892,12 @@ internal static class StaticText
             zhTW: "內容匹配: [white on deepskyblue1]HTTP Live Streaming[/]",
             enUS: "Content Matched: [white on deepskyblue1]HTTP Live Streaming[/]"
         ),
+        ["matchBinaryData"] = new TextContainer
+        (
+            zhCN: "内容匹配: [white on deepskyblue1]Binary Data[/]",
+            zhTW: "內容匹配: [white on deepskyblue1]Binary Data[/]",
+            enUS: "Content Matched: [white on deepskyblue1]Binary Data[/]"
+        ),
         ["partMerge"] = new TextContainer
         (
             zhCN: "分片数量大于1800个，开始分块合并...",
@@ -900,9 +906,9 @@ internal static class StaticText
         ),
         ["notSupported"] = new TextContainer
         (
-            zhCN: "当前输入不受支持: ",
-            zhTW: "當前輸入不受支援: ",
-            enUS: "Input not supported: "
+            zhCN: "当前输入不受支持 ",
+            zhTW: "當前輸入不受支援 ",
+            enUS: "Input not supported "
         ),
         ["parsingStream"] = new TextContainer
         (

--- a/src/N_m3u8DL-RE.Common/Util/BinaryContentCheckUtil.cs
+++ b/src/N_m3u8DL-RE.Common/Util/BinaryContentCheckUtil.cs
@@ -1,0 +1,84 @@
+namespace N_m3u8DL_RE.Common.Util;
+
+public static class BinaryContentCheckUtil
+{
+    public static bool LooksLikeBinary(ReadOnlySpan<byte> data)
+    {
+        if (data.Length == 0) return false;
+
+        int nonTextCount = 0;
+        int total = 0;
+
+        for (int i = 0; i < data.Length;)
+        {
+            byte b = data[i];
+            total++;
+
+            // NULL 字节 → 几乎可以肯定是二进制
+            if (b == 0x00)
+                return true;
+
+            // 可打印 ASCII
+            if (b is >= 0x20 and <= 0x7E)
+            {
+                i++;
+                continue;
+            }
+
+            // 常见控制符（\n \r \t）
+            if (b is 0x09 or 0x0A or 0x0D)
+            {
+                i++;
+                continue;
+            }
+
+            // UTF-8 多字节字符（包括中文）
+            int seqLen = GetUtf8SequenceLength(b);
+            if (seqLen > 1 && i + seqLen <= data.Length && IsValidUtf8Sequence(data.Slice(i, seqLen)))
+            {
+                i += seqLen;
+                continue;
+            }
+
+            // 其他都算非文本
+            nonTextCount++;
+            i++;
+        }
+
+        // 计算比例：非文本字节超过30% 视为二进制
+        double ratio = (double)nonTextCount / total;
+        return ratio > 0.3;
+    }
+
+    private static int GetUtf8SequenceLength(byte b)
+    {
+        if ((b & 0x80) == 0x00) return 1; // 0xxxxxxx
+        if ((b & 0xE0) == 0xC0) return 2; // 110xxxxx
+        if ((b & 0xF0) == 0xE0) return 3; // 1110xxxx
+        if ((b & 0xF8) == 0xF0) return 4; // 11110xxx
+        return 1;
+    }
+
+    private static bool IsValidUtf8Sequence(ReadOnlySpan<byte> seq)
+    {
+        if (seq.Length <= 1) return false;
+        for (int i = 1; i < seq.Length; i++)
+        {
+            if ((seq[i] & 0xC0) != 0x80)
+                return false;
+        }
+        return true;
+    }
+    
+    public static bool IsMpeg2TsBuffer(ReadOnlySpan<byte> buffer)
+    {
+        const int packetSize = 188;
+        if (buffer.Length < packetSize) return false;
+        int syncCount = 0;
+        for (int i = 0; i < Math.Min(buffer.Length / packetSize, 5); i++)
+        {
+            if (buffer[i * packetSize] == 0x47) syncCount++;
+        }
+        return syncCount >= 3;
+    }
+}

--- a/src/N_m3u8DL-RE.Common/Util/HTTPUtil.cs
+++ b/src/N_m3u8DL-RE.Common/Util/HTTPUtil.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net;
 using System.Net.Http.Headers;
+using System.Text;
 using N_m3u8DL_RE.Common.Log;
 using N_m3u8DL_RE.Common.Resource;
 
@@ -24,7 +25,7 @@ public static class HTTPUtil
 
     private static async Task<HttpResponseMessage> DoGetAsync(string url, Dictionary<string, string>? headers = null)
     {
-        Logger.Debug(ResString.fetch + url); 
+        Logger.Debug(ResString.fetch + url);
         using var webRequest = new HttpRequestMessage(HttpMethod.Get, url);
         webRequest.Headers.TryAddWithoutValidation("Accept-Encoding", "gzip, deflate");
         webRequest.Headers.CacheControl = CacheControlHeaderValue.Parse("no-cache");
@@ -36,6 +37,7 @@ public static class HTTPUtil
                 webRequest.Headers.TryAddWithoutValidation(item.Key, item.Value);
             }
         }
+
         Logger.Debug(webRequest.Headers.ToString());
         // 手动处理跳转，以免自定义Headers丢失
         var webResponse = await AppHttpClient.SendAsync(webRequest, HttpCompletionOption.ResponseHeadersRead);
@@ -56,7 +58,7 @@ public static class HTTPUtil
                 {
                     redirectedUrl = respHeaders.Location.AbsoluteUri;
                 }
-                    
+
                 if (redirectedUrl != url)
                 {
                     Logger.Extra($"Redirected => {redirectedUrl}");
@@ -64,6 +66,7 @@ public static class HTTPUtil
                 }
             }
         }
+
         // 手动将跳转后的URL设置进去, 用于后续取用
         webResponse.Headers.Location = new Uri(url);
         webResponse.EnsureSuccessStatusCode();
@@ -76,6 +79,7 @@ public static class HTTPUtil
         {
             return await File.ReadAllBytesAsync(new Uri(url).LocalPath);
         }
+
         var webResponse = await DoGetAsync(url, headers);
         var bytes = await webResponse.Content.ReadAsByteArrayAsync();
         Logger.Debug(HexUtil.BytesToHex(bytes, " "));
@@ -96,14 +100,6 @@ public static class HTTPUtil
         return htmlCode;
     }
 
-    private static bool CheckMPEG2TS(HttpResponseMessage? webResponse)
-    {
-        var mediaType = webResponse?.Content.Headers.ContentType?.MediaType?.ToLower();
-        if (webResponse?.Content.Headers.ContentLength != null)
-            return false;
-        return mediaType is "video/ts" or "video/mp2t" or "video/mpeg" or "application/octet-stream";
-    }
-
     /// <summary>
     /// 获取网页源码和跳转后的URL
     /// </summary>
@@ -112,18 +108,66 @@ public static class HTTPUtil
     /// <returns>(Source Code, RedirectedUrl)</returns>
     public static async Task<(string, string)> GetWebSourceAndNewUrlAsync(string url, Dictionary<string, string>? headers = null)
     {
-        string htmlCode;
         var webResponse = await DoGetAsync(url, headers);
-        if (CheckMPEG2TS(webResponse))
+        var htmlCode = "";
+
+        // 如果响应是压缩的（gzip/deflate/br），直接按文本处理
+        var encodings = webResponse.Content.Headers.ContentEncoding;
+        if (encodings.Count != 0)
         {
-            htmlCode = ResString.ReLiveTs;
-        }
-        else
-        {
+            Logger.Debug($"Detected compression: {string.Join(",", encodings)}");
             htmlCode = await webResponse.Content.ReadAsStringAsync();
+            return (htmlCode, webResponse.RequestMessage?.RequestUri?.AbsoluteUri ?? url);
         }
-        Logger.Debug(htmlCode);
-        return (htmlCode, webResponse.Headers.Location != null ? webResponse.Headers.Location.AbsoluteUri : url);
+
+        // 打开流，读取少量样本检测类型
+        const int sampleSize = 4096;
+        await using var responseStream = await webResponse.Content.ReadAsStreamAsync();
+
+        var buffer = new byte[sampleSize];
+        var bytesRead = await responseStream.ReadAsync(buffer.AsMemory(0, sampleSize));
+
+        // MPEG-TS 检测
+        if (BinaryContentCheckUtil.IsMpeg2TsBuffer(buffer.AsSpan(0, bytesRead)))
+        {
+            Logger.Debug("Detected MPEG-TS stream");
+            return (ResString.ReLiveTs, url);
+        }
+
+        // 启发式判断二进制
+        if (BinaryContentCheckUtil.LooksLikeBinary(buffer.AsSpan(0, bytesRead)))
+        {
+            Logger.Debug("Heuristic detection: binary data");
+            return (ResString.ReBinaryData, url);
+        }
+
+        // 否则是文本，完整读取
+        using var ms = new MemoryStream();
+        ms.Write(buffer, 0, bytesRead);
+        await responseStream.CopyToAsync(ms);
+
+        var allBytes = ms.ToArray();
+        var encoding = GetEncodingFromResponse(webResponse) ?? Encoding.UTF8;
+        htmlCode = encoding.GetString(allBytes);
+
+        return (htmlCode, webResponse.RequestMessage?.RequestUri?.AbsoluteUri ?? url);
+    }
+
+    private static Encoding? GetEncodingFromResponse(HttpResponseMessage response)
+    {
+        var contentType = response.Content.Headers.ContentType;
+        if (contentType?.CharSet == null) return null;
+        
+        try
+        {
+            return Encoding.GetEncoding(contentType.CharSet);
+        }
+        catch (ArgumentException)
+        {
+            // 无效 charset，回退
+        }
+
+        return null;
     }
 
     public static async Task<string> GetPostResponseAsync(string Url, byte[] postData)

--- a/src/N_m3u8DL-RE.Parser/StreamExtractor.cs
+++ b/src/N_m3u8DL-RE.Parser/StreamExtractor.cs
@@ -87,6 +87,11 @@ public class StreamExtractor
             Logger.InfoMarkUp(ResString.matchTS);
             extractor = new LiveTSExtractor(parserConfig);
         }
+        else if (rawText == ResString.ReBinaryData)
+        {
+            Logger.InfoMarkUp(ResString.matchBinaryData);
+            throw new NotSupportedException(ResString.notSupported);
+        }
         else
         {
             throw new NotSupportedException(ResString.notSupported);

--- a/src/N_m3u8DL-RE/CommandLine/CommandInvoker.cs
+++ b/src/N_m3u8DL-RE/CommandLine/CommandInvoker.cs
@@ -15,7 +15,7 @@ namespace N_m3u8DL_RE.CommandLine;
 
 internal static partial class CommandInvoker
 {
-    public const string VERSION_INFO = "N_m3u8DL-RE (Beta version) 20251027";
+    public const string VERSION_INFO = "N_m3u8DL-RE (Beta version) 20251029";
 
     [GeneratedRegex("((best|worst)\\d*|all)")]
     private static partial Regex ForStrRegex();


### PR DESCRIPTION
Fix #732 

检测逻辑 | 判断方式 | 优点
-- | -- | --
压缩检测 | Content-Encoding | 立即判定为文本，节省 IO
TS 检测 | 读取前 188/376/564 字节 | 快速识别 MPEG-TS 流
启发式检测 | 判断可打印字符、UTF-8 合法性、NULL 字节比例 | 能区分中文文本与二进制数据
内存安全 | 仅读取前 4KB 采样，不整块加载 | 适合超大响应体
