### PR TITLE
fix: defer `-sv` resolution validation for single m3u8 stream

### DIFF
--- a/src/N_m3u8DL-RE.Common/Resource/ResString.cs
+++ b/src/N_m3u8DL-RE.Common/Resource/ResString.cs
@@ -130,6 +130,8 @@ public static class ResString
     public static string promptInfo => GetText("promptInfo");
     public static string promptTitle => GetText("promptTitle");
     public static string readingInfo => GetText("readingInfo");
+    public static string resolutionFilterNotMatch => GetText("resolutionFilterNotMatch");
+    public static string resolutionFilterExpectedActual => GetText("resolutionFilterExpectedActual");
     public static string searchKey => GetText("searchKey");
     public static string decryptionFailed => GetText("decryptionFailed");
     public static string segmentCountCheckNotPass => GetText("segmentCountCheckNotPass");

--- a/src/N_m3u8DL-RE.Common/Resource/StaticText.cs
+++ b/src/N_m3u8DL-RE.Common/Resource/StaticText.cs
@@ -940,6 +940,18 @@ internal static class StaticText
             zhTW: "讀取媒體訊息...",
             enUS: "Reading media info..."
         ),
+        ["resolutionFilterNotMatch"] = new TextContainer
+        (
+            zhCN: "-sv res 与实际视频分辨率不符",
+            zhTW: "-sv res 與實際影片解析度不符",
+            enUS: "-sv res does not match the actual video resolution"
+        ),
+        ["resolutionFilterExpectedActual"] = new TextContainer
+        (
+            zhCN: "期望: {} | 实际: {}",
+            zhTW: "期望: {} | 實際: {}",
+            enUS: "Expected: {} | Actual: {}"
+        ),
         ["searchKey"] = new TextContainer
         (
             zhCN: "正在尝试从文本文件搜索KEY...",

--- a/src/N_m3u8DL-RE/DownloadManager/SimpleDownloadManager.cs
+++ b/src/N_m3u8DL-RE/DownloadManager/SimpleDownloadManager.cs
@@ -94,7 +94,7 @@ internal class SimpleDownloadManager
         if (!resolutionReg.IsMatch(videoResolution))
         {
             Logger.ErrorMarkUp($"[red]{ResString.resolutionFilterNotMatch}[/]");
-            Logger.ErrorMarkUp($"[grey]{ResString.resolutionFilterExpectedActual}[/]", resolutionReg, videoResolution);
+            Logger.ErrorMarkUp($"[grey]{ResString.resolutionFilterExpectedActual}[/]", resolutionReg.ToString().EscapeMarkup(), videoResolution.EscapeMarkup());
             return false;
         }
 

--- a/src/N_m3u8DL-RE/DownloadManager/SimpleDownloadManager.cs
+++ b/src/N_m3u8DL-RE/DownloadManager/SimpleDownloadManager.cs
@@ -77,6 +77,30 @@ internal class SimpleDownloadManager
         }
     }
 
+    private bool ValidateVideoResolution(StreamSpec streamSpec, List<Mediainfo> mediainfos)
+    {
+        var resolutionReg = DownloaderConfig.MyOptions.VideoFilter?.ResolutionReg;
+        if (resolutionReg == null)
+            return true;
+
+        if (streamSpec.MediaType is MediaType.AUDIO or MediaType.SUBTITLES)
+            return true;
+
+        var videoResolution = mediainfos.FirstOrDefault(m => m.Type == "Video" && !string.IsNullOrEmpty(m.Resolution))?.Resolution;
+        if (string.IsNullOrEmpty(videoResolution))
+            return true;
+
+        streamSpec.Resolution ??= videoResolution;
+        if (!resolutionReg.IsMatch(videoResolution))
+        {
+            Logger.ErrorMarkUp($"[red]{ResString.resolutionFilterNotMatch}[/]");
+            Logger.ErrorMarkUp($"[grey]{ResString.resolutionFilterExpectedActual}[/]", resolutionReg, videoResolution);
+            return false;
+        }
+
+        return true;
+    }
+
     private async Task<bool> DownloadStreamAsync(StreamSpec streamSpec, ProgressTask task, SpeedContainer speedContainer)
     {
         speedContainer.ResetVars();
@@ -203,6 +227,8 @@ internal class SimpleDownloadManager
                     Logger.WarnMarkUp(ResString.readingInfo);
                     mediaInfos = await MediainfoUtil.ReadInfoAsync(DownloaderConfig.MyOptions.FFmpegBinaryPath!, result.ActualFilePath);
                     mediaInfos.ForEach(info => Logger.InfoMarkUp(info.ToStringMarkUp()));
+                    if (!ValidateVideoResolution(streamSpec, mediaInfos))
+                        return false;
                     ChangeSpecInfo(streamSpec, mediaInfos, ref useAACFilter);
                     readInfo = true;
                 }
@@ -277,6 +303,8 @@ internal class SimpleDownloadManager
                     Logger.WarnMarkUp(ResString.readingInfo);
                     mediaInfos = await MediainfoUtil.ReadInfoAsync(DownloaderConfig.MyOptions.FFmpegBinaryPath!, result!.ActualFilePath);
                     mediaInfos.ForEach(info => Logger.InfoMarkUp(info.ToStringMarkUp()));
+                    if (!ValidateVideoResolution(streamSpec, mediaInfos))
+                        return false;
                     ChangeSpecInfo(streamSpec, mediaInfos, ref useAACFilter);
                     readInfo = true;
                 }

--- a/src/N_m3u8DL-RE/Util/FilterUtil.cs
+++ b/src/N_m3u8DL-RE/Util/FilterUtil.cs
@@ -24,7 +24,19 @@ public static class FilterUtil
         if (filter.CodecsReg != null)
             inputs = inputs.Where(i => i.Codecs != null && filter.CodecsReg.IsMatch(i.Codecs));
         if (filter.ResolutionReg != null)
-            inputs = inputs.Where(i => i.Resolution != null && filter.ResolutionReg.IsMatch(i.Resolution));
+        {
+            var currentInputs = inputs.ToList();
+            var matched = currentInputs.Where(i => i.Resolution != null && filter.ResolutionReg.IsMatch(i.Resolution)).ToList();
+
+            if (matched.Count > 0)
+            {
+                inputs = matched;
+            }
+            else if (!(currentInputs.Count == 1 && string.IsNullOrEmpty(currentInputs[0].Resolution)))
+            {
+                inputs = [];
+            }
+        }
         if (filter.FrameRateReg != null)
             inputs = inputs.Where(i => i.FrameRate != null && filter.FrameRateReg.IsMatch($"{i.FrameRate}"));
         if (filter.ChannelsReg != null)


### PR DESCRIPTION
## Summary
Fix `-sv` resolution select behavior for single stream m3u8 inputs by deferring validation until actual media info is available.

## Changes
Keep single stream candidates when playlist resolution metadata is missing.
Validate the resolution parameter against probed video resolution after media info is read.
Fail gracefully with user-friendly error messages.

## Result
Master m3u8: filter behavior unchanged.
Single m3u8: matches continue; mismatches fail clearly and safely.