### PR TITLE
added BOM handling (fixes #865)

### DIFF
--- a/src/N_m3u8DL-RE.Common/Util/HTTPUtil.cs
+++ b/src/N_m3u8DL-RE.Common/Util/HTTPUtil.cs
@@ -145,11 +145,12 @@ public static class HTTPUtil
         using var ms = new MemoryStream();
         ms.Write(buffer, 0, bytesRead);
         await responseStream.CopyToAsync(ms);
-
-        var allBytes = ms.ToArray();
-        var encoding = GetEncodingFromResponse(webResponse) ?? Encoding.UTF8;
-        htmlCode = encoding.GetString(allBytes);
-
+        ms.Position = 0;
+        
+        var charsetEncoding = GetEncodingFromResponse(webResponse) ?? Encoding.UTF8;
+        using var reader = new StreamReader(ms, charsetEncoding, detectEncodingFromByteOrderMarks: true);
+        htmlCode = await reader.ReadToEndAsync();
+        
         return (htmlCode, webResponse.RequestMessage?.RequestUri?.AbsoluteUri ?? url);
     }
 


### PR DESCRIPTION
Handles UTF-8, UTF-16-LE and UTF-16-BE Byte order marks (see [StreamReader](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs#L129))