### PR TITLE
WebVTT: don't merge cues if Settings don't match

### DIFF
--- a/src/N_m3u8DL-RE.Common/Entity/WebVttSub.cs
+++ b/src/N_m3u8DL-RE.Common/Entity/WebVttSub.cs
@@ -142,7 +142,7 @@ public partial class WebVttSub
             
             // 如果相差只有1ms，且payload相同，则拼接
             var last = this.Cues.LastOrDefault();
-            if (last != null && this.Cues.Count > 0 && (item.StartTime - last.EndTime).TotalMilliseconds <= 1 && item.Payload == last.Payload) 
+            if (last != null && this.Cues.Count > 0 && (item.StartTime - last.EndTime).TotalMilliseconds <= 1 && item.Payload == last.Payload && item.Settings == last.Settings)
             {
                 last.EndTime = item.EndTime;
             }


### PR DESCRIPTION
## Problem description

WebVTT subtitle authors *may* use two cues with the same time and payload to express that something has been said twice, placing each cue in a different place (see Real-world example). N_m3u8DL-RE currently discards the second cue, even if its position (and/or other settings) differ from the first.

## Proposed fix

Only deduplicate cues when their `Settings` fields match.

### Possible issues

Since this solution only performs a single string equality check, it returns a false-negative (cues _don't_ get deduplicated) if the order of settings doesn't match. However, I consider that to be a _skill issue_ on the part of the subtitle author.

## Attachments

### Diff (before the change/fix)

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3c0537bd-fb8c-4b75-af71-c115fdd224cf" />

Left: source file
Right: N_m3u8DL-RE output

### Real-world example

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a5617e61-d246-44b5-be19-e10d23e6c9bf" />

Two cues at different positions used during a musical duet.
