### PR TITLE
Fix --mux-import / selectors failing when a value contains a quote or apostrophe (#737)

### DIFF
--- a/src/N_m3u8DL-RE.Tests/CommandLine/ComplexParamParserTests.cs
+++ b/src/N_m3u8DL-RE.Tests/CommandLine/ComplexParamParserTests.cs
@@ -1,0 +1,62 @@
+using N_m3u8DL_RE.CommandLine;
+
+namespace N_m3u8DL_RE.Tests.CommandLine;
+
+public class ComplexParamParserTests
+{
+    [Fact]
+    public void GetValue_SimpleKeyValue_ReturnsValue()
+    {
+        var parser = new ComplexParamParser("path=foo.srt:lang=en");
+        Assert.Equal("foo.srt", parser.GetValue("path"));
+        Assert.Equal("en", parser.GetValue("lang"));
+    }
+
+    [Fact]
+    public void GetValue_MissingKey_ReturnsNull()
+    {
+        var parser = new ComplexParamParser("path=foo.srt");
+        Assert.Null(parser.GetValue("lang"));
+    }
+
+    [Fact]
+    public void GetValue_KeyWithoutValue_ReturnsTrue()
+    {
+        var parser = new ComplexParamParser("path=foo.srt:default");
+        Assert.Equal("true", parser.GetValue("default"));
+    }
+
+    // Issue #737: an apostrophe inside the value (common in episode titles)
+    // used to throw "Parse Argument [path] failed!".
+    [Fact]
+    public void GetValue_ValueWithApostrophe_IsPreserved()
+    {
+        var parser = new ComplexParamParser("path=S07E01 What's Next.srt:lang=en");
+        Assert.Equal("S07E01 What's Next.srt", parser.GetValue("path"));
+        Assert.Equal("en", parser.GetValue("lang"));
+    }
+
+    [Fact]
+    public void GetValue_ValueWithDoubleQuoteInside_IsPreserved()
+    {
+        var parser = new ComplexParamParser("name=He said \"hi\":lang=en");
+        Assert.Equal("He said \"hi\"", parser.GetValue("name"));
+    }
+
+    [Theory]
+    [InlineData("path=\"foo bar.srt\"", "foo bar.srt")]
+    [InlineData("path='foo bar.srt'", "foo bar.srt")]
+    public void GetValue_SurroundingQuotesArePairStripped(string arg, string expected)
+    {
+        var parser = new ComplexParamParser(arg);
+        Assert.Equal(expected, parser.GetValue("path"));
+    }
+
+    [Fact]
+    public void GetValue_EscapedColonIsKeptInValue()
+    {
+        var parser = new ComplexParamParser(@"name=a\:b:lang=en");
+        Assert.Equal("a:b", parser.GetValue("name"));
+        Assert.Equal("en", parser.GetValue("lang"));
+    }
+}

--- a/src/N_m3u8DL-RE.Tests/N_m3u8DL-RE.Tests.csproj
+++ b/src/N_m3u8DL-RE.Tests/N_m3u8DL-RE.Tests.csproj
@@ -24,6 +24,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\N_m3u8DL-RE.Parser\N_m3u8DL-RE.Parser.csproj" />
+        <ProjectReference Include="..\N_m3u8DL-RE\N_m3u8DL-RE.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/N_m3u8DL-RE/CommandLine/ComplexParamParser.cs
+++ b/src/N_m3u8DL-RE/CommandLine/ComplexParamParser.cs
@@ -41,10 +41,15 @@ internal class ComplexParamParser
                 }
             }
 
-            var resultStr = result.ToString().Trim().Trim('\"').Trim('\'');
+            var resultStr = result.ToString().Trim();
 
-            // 不应该有引号出现
-            if (resultStr.Contains('\"') || resultStr.Contains('\'')) throw new Exception();
+            // 仅去除成对的首尾引号, 保留值内部的引号(例如文件名中的撇号: What's Next)
+            if (resultStr.Length >= 2
+                && (resultStr[0] == '\"' || resultStr[0] == '\'')
+                && resultStr[^1] == resultStr[0])
+            {
+                resultStr = resultStr[1..^1];
+            }
 
             return resultStr;
         }

--- a/src/N_m3u8DL-RE/N_m3u8DL-RE.csproj
+++ b/src/N_m3u8DL-RE/N_m3u8DL-RE.csproj
@@ -23,4 +23,8 @@
     <PackageReference Include="System.CommandLine" Version="2.0.0-rc.2.25502.107" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="N_m3u8DL-RE.Tests" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Problem

`ComplexParamParser.GetValue` strips the surrounding quotes from a value and then **throws if the result still contains any `"` or `'` character**:

```csharp
var resultStr = result.ToString().Trim().Trim('\"').Trim('\'');
// 不应该有引号出现
if (resultStr.Contains('\"') || resultStr.Contains('\'')) throw new Exception();
```

This means any value that legitimately contains a quote/apostrophe fails to parse. A very common case is an episode title with an apostrophe (closes #737):

```
--mux-import path="S07E01 What's Next.srt":lang=en
=> Parse Argument [path] failed!
```

It is not limited to `--mux-import` — the same parser backs the `-sv`/`-sa`/`-ss` selectors and the `--drop-*` filters, so any `name=`/`path=` value containing an apostrophe was rejected.

## Fix

Only strip a **matched pair** of surrounding quotes and preserve any quotes inside the value:

```csharp
var resultStr = result.ToString().Trim();

// 仅去除成对的首尾引号, 保留值内部的引号(例如文件名中的撇号: What's Next)
if (resultStr.Length >= 2
    && (resultStr[0] == '\"' || resultStr[0] == '\'')
    && resultStr[^1] == resultStr[0])
{
    resultStr = resultStr[1..^1];
}
```

Escaped-colon (`\:`) handling and the `key` / `key=value` / bare-`key`→`true` behaviour are unchanged.

## Tests

Added `ComplexParamParserTests` covering simple key/value, missing key, bare key, surrounding-quote stripping, escaped colon, and the regression cases (apostrophe and internal double-quote preserved). To make the `internal` parser testable, the test project now references the main project and the main project exposes internals to it via `InternalsVisibleTo`.

All tests pass (`dotnet test`): 11 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)