### PR TITLE
Add change-mpd, change-host and improve HLS live refresh

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -59,6 +59,8 @@ Options:
   --write-meta-json                                       Write meta json after parsed [default: True]
   --append-url-params                                     Add Params of input Url to segments, useful for some
                                                           websites, such as kakao.com [default: False]
+  --change-mpd                                            Write downloaded MPD to raw.mpd, wait for replacement and
+                                                          press y to continue [default: False]
   -mt, --concurrent-download                              Concurrently download the selected audio, video and subtitles
                                                           [default: False]
   -H, --header <header>                                   Pass custom header(s) to server, Example:

--- a/README.en.md
+++ b/README.en.md
@@ -59,6 +59,10 @@ Options:
   --write-meta-json                                       Write meta json after parsed [default: True]
   --append-url-params                                     Add Params of input Url to segments, useful for some
                                                           websites, such as kakao.com [default: False]
+  --change-mpd                                            Write downloaded MPD to raw.mpd, wait for replacement and
+                                                          press y to continue [default: False]
+  --change-host <OLD|NEW>                                 Rewrite request host from OLD to NEW while keeping Host
+                                                          header as OLD
   -mt, --concurrent-download                              Concurrently download the selected audio, video and subtitles
                                                           [default: False]
   -H, --header <header>                                   Pass custom header(s) to server, Example:

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Options:
   --no-log                                                关闭日志文件输出 [default: False]
   --write-meta-json                                       解析后的信息是否输出json文件 [default: True]
   --append-url-params                                     将输入Url的Params添加至分片, 对某些网站很有用, 例如 kakao.com [default: False]
+  --change-mpd                                            下载MPD后写出 raw.mpd，等待用户替换并按 y 后继续处理 [default: False]
   -mt, --concurrent-download                              并发下载已选择的音频、视频和字幕 [default: False]
   -H, --header <header>                                   为HTTP请求设置特定的请求头, 例如:
                                                           -H "Cookie: mycookie" -H "User-Agent: iOS"

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Options:
   --no-log                                                关闭日志文件输出 [default: False]
   --write-meta-json                                       解析后的信息是否输出json文件 [default: True]
   --append-url-params                                     将输入Url的Params添加至分片, 对某些网站很有用, 例如 kakao.com [default: False]
+  --change-mpd                                            下载MPD后写出 raw.mpd，等待用户替换并按 y 后继续处理 [default: False]
+  --change-host <OLD|NEW>                                 请求OLD域名时改为请求NEW域名，但Host请求头保持OLD
   -mt, --concurrent-download                              并发下载已选择的音频、视频和字幕 [default: False]
   -H, --header <header>                                   为HTTP请求设置特定的请求头, 例如:
                                                           -H "Cookie: mycookie" -H "User-Agent: iOS"

--- a/src/N_m3u8DL-RE.Common/Util/HTTPUtil.cs
+++ b/src/N_m3u8DL-RE.Common/Util/HTTPUtil.cs
@@ -8,6 +8,8 @@ namespace N_m3u8DL_RE.Common.Util;
 
 public static class HTTPUtil
 {
+    public static Dictionary<string, string> ChangeHosts { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
     public static readonly HttpClientHandler HttpClientHandler = new()
     {
         AllowAutoRedirect = false,
@@ -23,20 +25,59 @@ public static class HTTPUtil
         DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher,
     };
 
+    public static HttpRequestMessage CreateRequest(HttpMethod method, string url)
+    {
+        var requestUri = new Uri(url);
+        var (actualUri, hostHeader) = ChangeHost(requestUri);
+        var request = new HttpRequestMessage(method, actualUri);
+        if (hostHeader != null)
+        {
+            request.Headers.Host = hostHeader;
+            Logger.Debug($"ChangeHost => {requestUri} -> {actualUri}, Host: {hostHeader}");
+        }
+
+        return request;
+    }
+
+    public static void ApplyHeaders(HttpRequestMessage request, Dictionary<string, string>? headers)
+    {
+        if (headers == null) return;
+
+        foreach (var item in headers)
+        {
+            if (item.Key.Equals("Host", StringComparison.OrdinalIgnoreCase))
+            {
+                request.Headers.Host ??= item.Value;
+                continue;
+            }
+
+            request.Headers.TryAddWithoutValidation(item.Key, item.Value);
+        }
+    }
+
+    private static (Uri actualUri, string? hostHeader) ChangeHost(Uri requestUri)
+    {
+        if (!requestUri.IsAbsoluteUri || ChangeHosts.Count == 0 || !ChangeHosts.TryGetValue(requestUri.Host, out var newHost) || string.IsNullOrWhiteSpace(newHost))
+        {
+            return (requestUri, null);
+        }
+
+        var builder = new UriBuilder(requestUri);
+        var replacementUri = new Uri($"{requestUri.Scheme}://{newHost}");
+        builder.Host = replacementUri.Host;
+        builder.Port = replacementUri.IsDefaultPort ? -1 : replacementUri.Port;
+        var hostHeader = requestUri.IsDefaultPort ? requestUri.Host : requestUri.Authority;
+        return (builder.Uri, hostHeader);
+    }
+
     private static async Task<HttpResponseMessage> DoGetAsync(string url, Dictionary<string, string>? headers = null)
     {
         Logger.Debug(ResString.fetch + url);
-        using var webRequest = new HttpRequestMessage(HttpMethod.Get, url);
+        using var webRequest = CreateRequest(HttpMethod.Get, url);
         webRequest.Headers.TryAddWithoutValidation("Accept-Encoding", "gzip, deflate");
         webRequest.Headers.CacheControl = CacheControlHeaderValue.Parse("no-cache");
         webRequest.Headers.Connection.Clear();
-        if (headers != null)
-        {
-            foreach (var item in headers)
-            {
-                webRequest.Headers.TryAddWithoutValidation(item.Key, item.Value);
-            }
-        }
+        ApplyHeaders(webRequest, headers);
 
         Logger.Debug(webRequest.Headers.ToString());
         // 手动处理跳转，以免自定义Headers丢失
@@ -117,7 +158,7 @@ public static class HTTPUtil
         {
             Logger.Debug($"Detected compression: {string.Join(",", encodings)}");
             htmlCode = await webResponse.Content.ReadAsStringAsync();
-            return (htmlCode, webResponse.RequestMessage?.RequestUri?.AbsoluteUri ?? url);
+            return (htmlCode, webResponse.Headers.Location?.AbsoluteUri ?? url);
         }
 
         // 打开流，读取少量样本检测类型
@@ -150,7 +191,7 @@ public static class HTTPUtil
         var encoding = GetEncodingFromResponse(webResponse) ?? Encoding.UTF8;
         htmlCode = encoding.GetString(allBytes);
 
-        return (htmlCode, webResponse.RequestMessage?.RequestUri?.AbsoluteUri ?? url);
+        return (htmlCode, webResponse.Headers.Location?.AbsoluteUri ?? url);
     }
 
     private static Encoding? GetEncodingFromResponse(HttpResponseMessage response)
@@ -173,7 +214,7 @@ public static class HTTPUtil
     public static async Task<string> GetPostResponseAsync(string Url, byte[] postData)
     {
         string htmlCode;
-        using HttpRequestMessage request = new(HttpMethod.Post, Url);
+        using var request = CreateRequest(HttpMethod.Post, Url);
         request.Headers.TryAddWithoutValidation("Content-Type", "application/json");
         request.Headers.TryAddWithoutValidation("Content-Length", postData.Length.ToString());
         request.Content = new ByteArrayContent(postData);

--- a/src/N_m3u8DL-RE.Parser/Config/ParserConfig.cs
+++ b/src/N_m3u8DL-RE.Parser/Config/ParserConfig.cs
@@ -58,6 +58,16 @@ public class ParserConfig
     public bool AppendUrlParams { get; set; } = false;
 
     /// <summary>
+    /// 保存下载到的MPD并等待用户替换后继续解析
+    /// </summary>
+    public bool ChangeMpd { get; set; } = false;
+
+    /// <summary>
+    /// ChangeMpd启用时写出并重新读取的MPD文件路径
+    /// </summary>
+    public string? ChangeMpdFilePath { get; set; }
+
+    /// <summary>
     /// 此参数将会传递给URL Processor中
     /// </summary>
     public string? UrlProcessorArgs { get; set; }

--- a/src/N_m3u8DL-RE.Parser/Extractor/HLSExtractor.cs
+++ b/src/N_m3u8DL-RE.Parser/Extractor/HLSExtractor.cs
@@ -17,6 +17,7 @@ internal class HLSExtractor : IExtractor
     private string BaseUrl = string.Empty;
     private string M3u8Content = string.Empty;
     private bool MasterM3u8Flag = false;
+    private readonly Dictionary<string, string> RefreshUrlMap = new(StringComparer.OrdinalIgnoreCase);
 
     public ParserConfig ParserConfig { get; set; }
 
@@ -24,6 +25,10 @@ internal class HLSExtractor : IExtractor
     {
         this.ParserConfig = parserConfig;
         this.M3u8Url = parserConfig.Url ?? string.Empty;
+        if (parserConfig.OriginalUrl.StartsWith("http") && !string.IsNullOrEmpty(parserConfig.Url) && parserConfig.Url != parserConfig.OriginalUrl)
+        {
+            RefreshUrlMap[parserConfig.Url] = parserConfig.OriginalUrl;
+        }
         this.SetBaseUrl();
     }
 
@@ -482,30 +487,124 @@ internal class HLSExtractor : IExtractor
         ];
     }
 
-    private async Task LoadM3u8FromUrlAsync(string url)
+    private async Task<string> LoadM3u8FromUrlAsync(string url, bool forceRefreshFromSource = false)
     {
         // Logger.Info(ResString.loadingUrl + url);
         if (url.StartsWith("file:"))
         {
             var uri = new Uri(url);
             this.M3u8Content = File.ReadAllText(uri.LocalPath);
+            this.M3u8Url = url;
+            this.SetBaseUrl();
+            this.PreProcessContent();
+            return this.M3u8Url;
         }
         else if (url.StartsWith("http"))
         {
+            var requestUrl = forceRefreshFromSource ? GetRefreshUrl(url) : url;
             try
             {
-                (this.M3u8Content, url) = await HTTPUtil.GetWebSourceAndNewUrlAsync(url, ParserConfig.Headers);
+                return await LoadHttpM3u8FromUrlAsync(requestUrl, url);
             }
-            catch (HttpRequestException) when (ParserConfig.OriginalUrl.StartsWith("http") && url != ParserConfig.OriginalUrl)
+            catch (Exception ex) when (CanRetryFromRefreshUrl(url, requestUrl, ex))
             {
-                // 当URL无法访问时，再请求原始URL
-                (this.M3u8Content, url) = await HTTPUtil.GetWebSourceAndNewUrlAsync(ParserConfig.OriginalUrl, ParserConfig.Headers);
+                Logger.WarnMarkUp("Can not load m3u8. Try refreshing url from previous url...");
+                return await LoadHttpM3u8FromUrlAsync(GetRefreshUrl(url), url);
+            }
+            catch (Exception ex) when (CanRetryFromOriginalUrl(url, requestUrl, ex))
+            {
+                Logger.WarnMarkUp("Can not load m3u8 from redirected url. Try refreshing url from original url...");
+                return await LoadHttpM3u8FromUrlAsync(ParserConfig.OriginalUrl, url);
             }
         }
 
-        this.M3u8Url = url;
-        this.SetBaseUrl();
-        this.PreProcessContent();
+        return this.M3u8Url;
+    }
+
+    private string GetRefreshUrl(string url)
+    {
+        if (RefreshUrlMap.TryGetValue(url, out var refreshUrl))
+        {
+            Logger.DebugMarkUp($"{url} => {refreshUrl}");
+            return refreshUrl;
+        }
+
+        return url;
+    }
+
+    private bool CanRetryFromRefreshUrl(string url, string requestUrl, Exception ex)
+    {
+        return IsRetryableM3u8Exception(ex) && RefreshUrlMap.TryGetValue(url, out var refreshUrl) && requestUrl != refreshUrl;
+    }
+
+    private bool CanRetryFromOriginalUrl(string url, string requestUrl, Exception ex)
+    {
+        if (!ParserConfig.OriginalUrl.StartsWith("http") || requestUrl == ParserConfig.OriginalUrl)
+            return false;
+
+        if (!IsRootM3u8Url(url))
+            return false;
+
+        return IsRetryableM3u8Exception(ex);
+    }
+
+    private static bool IsRetryableM3u8Exception(Exception ex)
+    {
+        return ex is HttpRequestException || ex.Message == ResString.badM3u8;
+    }
+
+    private bool IsRootM3u8Url(string url)
+    {
+        return url == ParserConfig.Url || url == ParserConfig.OriginalUrl || (RefreshUrlMap.TryGetValue(url, out var refreshUrl) && refreshUrl == ParserConfig.OriginalUrl);
+    }
+
+    private async Task<string> LoadHttpM3u8FromUrlAsync(string requestUrl, string sourceUrl)
+    {
+        var oldContent = this.M3u8Content;
+        var oldM3u8Url = this.M3u8Url;
+        var oldBaseUrl = this.BaseUrl;
+
+        try
+        {
+            (this.M3u8Content, var url) = await HTTPUtil.GetWebSourceAndNewUrlAsync(requestUrl, ParserConfig.Headers);
+            this.M3u8Url = url;
+            RegisterRefreshUrl(requestUrl, url);
+            if (sourceUrl != requestUrl)
+            {
+                RefreshUrlMap[sourceUrl] = requestUrl;
+            }
+            if (IsRootM3u8Url(sourceUrl) || requestUrl == ParserConfig.OriginalUrl)
+            {
+                ParserConfig.Url = url;
+            }
+
+            this.SetBaseUrl();
+            this.PreProcessContent();
+            return this.M3u8Url;
+        }
+        catch
+        {
+            this.M3u8Content = oldContent;
+            this.M3u8Url = oldM3u8Url;
+            this.BaseUrl = oldBaseUrl;
+            throw;
+        }
+    }
+
+    private void RegisterRefreshUrl(string requestUrl, string loadedUrl)
+    {
+        if (requestUrl.StartsWith("http") && loadedUrl.StartsWith("http") && loadedUrl != requestUrl)
+        {
+            RefreshUrlMap[loadedUrl] = requestUrl;
+        }
+    }
+
+    private void UpdateStreamUrl(StreamSpec streamSpec)
+    {
+        if (string.IsNullOrEmpty(M3u8Url))
+            return;
+
+        streamSpec.Url = M3u8Url;
     }
 
     /// <summary>
@@ -538,7 +637,7 @@ internal class HLSExtractor : IExtractor
                 // 直接重新加载m3u8
                 await LoadM3u8FromUrlAsync(lists[i].Url!);
             }
-            catch (HttpRequestException) when (MasterM3u8Flag)
+            catch (Exception ex) when (MasterM3u8Flag && (ex is HttpRequestException || ex.Message == ResString.badM3u8))
             {
                 Logger.WarnMarkUp("Can not load m3u8. Try refreshing url from master url...");
                 // 当前URL无法加载 尝试从Master链接中刷新URL
@@ -547,6 +646,7 @@ internal class HLSExtractor : IExtractor
             }
 
             var newPlaylist = await ParseListAsync();
+            UpdateStreamUrl(lists[i]);
             if (lists[i].Playlist?.MediaInit != null)
                 lists[i].Playlist!.MediaParts = newPlaylist.MediaParts; // 不更新init
             else
@@ -569,5 +669,19 @@ internal class HLSExtractor : IExtractor
     public async Task RefreshPlayListAsync(List<StreamSpec> streamSpecs)
     {
         await FetchPlayListAsync(streamSpecs);
+    }
+
+    public async Task RefreshPlayListFromRefreshUrlAsync(List<StreamSpec> streamSpecs)
+    {
+        for (int i = 0; i < streamSpecs.Count; i++)
+        {
+            await LoadM3u8FromUrlAsync(streamSpecs[i].Url!, forceRefreshFromSource: true);
+            var newPlaylist = await ParseListAsync();
+            UpdateStreamUrl(streamSpecs[i]);
+            if (streamSpecs[i].Playlist?.MediaInit != null)
+                streamSpecs[i].Playlist!.MediaParts = newPlaylist.MediaParts; // 不更新init
+            else
+                streamSpecs[i].Playlist = newPlaylist;
+        }
     }
 }

--- a/src/N_m3u8DL-RE.Parser/StreamExtractor.cs
+++ b/src/N_m3u8DL-RE.Parser/StreamExtractor.cs
@@ -7,6 +7,7 @@ using N_m3u8DL_RE.Parser.Constants;
 using N_m3u8DL_RE.Parser.Extractor;
 using N_m3u8DL_RE.Common.Util;
 using N_m3u8DL_RE.Common.Enum;
+using System.Text;
 
 namespace N_m3u8DL_RE.Parser;
 
@@ -53,10 +54,47 @@ public class StreamExtractor
         }
         
         this.rawText = rawText.Trim();
+        if (parserConfig.ChangeMpd && IsDashContent(this.rawText))
+        {
+            this.rawText = await WaitForMpdReplacementAsync(this.rawText);
+        }
         LoadSourceFromText(this.rawText);
     }
 
-    [MemberNotNull(nameof(this.rawText), nameof(this.extractor))]
+    private static bool IsDashContent(string rawText)
+    {
+        return rawText.Contains("</MPD>") && rawText.Contains("<MPD");
+    }
+
+    private async Task<string> WaitForMpdReplacementAsync(string mpdContent)
+    {
+        var mpdPath = parserConfig.ChangeMpdFilePath;
+        if (string.IsNullOrWhiteSpace(mpdPath))
+        {
+            mpdPath = Path.Combine(Environment.CurrentDirectory, "raw.mpd");
+        }
+
+        var dir = Path.GetDirectoryName(mpdPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        await File.WriteAllTextAsync(mpdPath, mpdContent, Encoding.UTF8);
+        Logger.Warn($"MPD saved to: {mpdPath}");
+        Logger.Warn("请替换该 MPD 文件，替换完成后按 y 继续处理。");
+
+        ConsoleKeyInfo key;
+        do
+        {
+            key = Console.ReadKey(intercept: true);
+        } while (char.ToLowerInvariant(key.KeyChar) != 'y');
+
+        Console.WriteLine();
+        return (await File.ReadAllTextAsync(mpdPath)).Trim();
+    }
+
+    [MemberNotNull(nameof(rawText), nameof(extractor))]
     private void LoadSourceFromText(string rawText)
     {
         var rawType = "txt";
@@ -68,7 +106,7 @@ public class StreamExtractor
             extractor = new HLSExtractor(parserConfig);
             rawType = "m3u8";
         }
-        else if (rawText.Contains("</MPD>") && rawText.Contains("<MPD"))
+        else if (IsDashContent(rawText))
         {
             Logger.InfoMarkUp(ResString.matchDASH);
             // extractor = new DASHExtractor(parserConfig);

--- a/src/N_m3u8DL-RE.Parser/StreamExtractor.cs
+++ b/src/N_m3u8DL-RE.Parser/StreamExtractor.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using N_m3u8DL_RE.Parser.Config;
 using N_m3u8DL_RE.Common.Entity;
 using N_m3u8DL_RE.Common.Log;
@@ -7,6 +7,7 @@ using N_m3u8DL_RE.Parser.Constants;
 using N_m3u8DL_RE.Parser.Extractor;
 using N_m3u8DL_RE.Common.Util;
 using N_m3u8DL_RE.Common.Enum;
+using System.Text;
 
 namespace N_m3u8DL_RE.Parser;
 
@@ -53,9 +54,46 @@ public class StreamExtractor
         }
         
         this.rawText = rawText.Trim();
+        if (parserConfig.ChangeMpd && IsDashContent(this.rawText))
+        {
+            this.rawText = await WaitForMpdReplacementAsync(this.rawText);
+        }
         LoadSourceFromText(this.rawText);
     }
 
+
+    private static bool IsDashContent(string rawText)
+    {
+        return rawText.Contains("</MPD>") && rawText.Contains("<MPD");
+    }
+
+    private async Task<string> WaitForMpdReplacementAsync(string mpdContent)
+    {
+        var mpdPath = parserConfig.ChangeMpdFilePath;
+        if (string.IsNullOrWhiteSpace(mpdPath))
+        {
+            mpdPath = Path.Combine(Environment.CurrentDirectory, "raw.mpd");
+        }
+
+        var dir = Path.GetDirectoryName(mpdPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        await File.WriteAllTextAsync(mpdPath, mpdContent, Encoding.UTF8);
+        Logger.Warn($"MPD saved to: {mpdPath}");
+        Logger.Warn("Please replace this MPD file, then press y to continue.");
+
+        ConsoleKeyInfo key;
+        do
+        {
+            key = Console.ReadKey(intercept: true);
+        } while (char.ToLowerInvariant(key.KeyChar) != 'y');
+
+        Console.WriteLine();
+        return (await File.ReadAllTextAsync(mpdPath)).Trim();
+    }
     [MemberNotNull(nameof(rawText), nameof(extractor))]
     private void LoadSourceFromText(string rawText)
     {
@@ -68,7 +106,7 @@ public class StreamExtractor
             extractor = new HLSExtractor(parserConfig);
             rawType = "m3u8";
         }
-        else if (rawText.Contains("</MPD>") && rawText.Contains("<MPD"))
+        else if (IsDashContent(rawText))
         {
             Logger.InfoMarkUp(ResString.matchDASH);
             // extractor = new DASHExtractor(parserConfig);
@@ -144,6 +182,27 @@ public class StreamExtractor
             await RetryUtil.WebRequestRetryAsync(async () =>
             {
                 await extractor.RefreshPlayListAsync(streamSpecs);
+                return true;
+            }, retryDelayMilliseconds: 1000, maxRetries: 5);
+        }
+        finally
+        {
+            semaphore.Release();
+        }
+    }
+
+    public async Task RefreshPlayListFromRefreshUrlAsync(List<StreamSpec> streamSpecs)
+    {
+        try
+        {
+            await semaphore.WaitAsync();
+            await RetryUtil.WebRequestRetryAsync(async () =>
+            {
+                if (extractor is HLSExtractor hlsExtractor)
+                    await hlsExtractor.RefreshPlayListFromRefreshUrlAsync(streamSpecs);
+                else
+                    await extractor.RefreshPlayListAsync(streamSpecs);
+
                 return true;
             }, retryDelayMilliseconds: 1000, maxRetries: 5);
         }

--- a/src/N_m3u8DL-RE/CommandLine/CommandInvoker.cs
+++ b/src/N_m3u8DL-RE/CommandLine/CommandInvoker.cs
@@ -58,6 +58,7 @@ internal static partial class CommandInvoker
     private static readonly Option<bool> CheckSegmentsCount = new Option<bool>("--check-segments-count") { Description = ResString.cmd_checkSegmentsCount }.WithDefault(true);
     private static readonly Option<bool> WriteMetaJson = new Option<bool>("--write-meta-json") { Description = ResString.cmd_writeMetaJson }.WithDefault(true);
     private static readonly Option<bool> AppendUrlParams = new Option<bool>("--append-url-params") { Description = ResString.cmd_appendUrlParams }.WithDefault(false);
+    private static readonly Option<bool> ChangeMpd = new Option<bool>("--change-mpd") { Description = "Write downloaded MPD to raw.mpd, wait for replacement, then continue." }.WithDefault(false);
     private static readonly Option<bool> MP4RealTimeDecryption = new Option<bool>("--mp4-real-time-decryption") { Description = ResString.cmd_MP4RealTimeDecryption }.WithDefault(false);
     private static readonly Option<bool> UseShakaPackager = new Option<bool>("--use-shaka-packager") { Hidden = true, Description = ResString.cmd_useShakaPackager }.WithDefault(false);
     private static readonly Option<DecryptEngine> DecryptionEngine = new ("--decryption-engine") { Description = ResString.cmd_decryptionEngine, DefaultValueFactory = _ => DecryptEngine.MP4DECRYPT };
@@ -635,6 +636,7 @@ internal static partial class CommandInvoker
             SkipDownload = result.GetValue(SkipDownload),
             WriteMetaJson = result.GetValue(WriteMetaJson),
             AppendUrlParams = result.GetValue(AppendUrlParams),
+            ChangeMpd = result.GetValue(ChangeMpd),
             SavePattern = result.GetValue(SavePattern),
             Keys = result.GetValue(Keys),
             UrlProcessorArgs = result.GetValue(UrlProcessorArgs),
@@ -726,7 +728,7 @@ internal static partial class CommandInvoker
         var rootCommand = new RootCommand(VERSION_INFO)
         {
             Input, TmpDir, SaveDir, SaveName, SavePattern, LogFilePath, BaseUrl, ThreadCount, DownloadRetryCount, HttpRequestTimeout, ForceAnsiConsole, NoAnsiColor,AutoSelect, SkipMerge, SkipDownload, CheckSegmentsCount,
-            BinaryMerge, UseFFmpegConcatDemuxer, DelAfterDone, NoDateInfo, NoLog, WriteMetaJson, AppendUrlParams, ConcurrentDownload, Headers, SubOnly, SubtitleFormat, AutoSubtitleFix,
+            BinaryMerge, UseFFmpegConcatDemuxer, DelAfterDone, NoDateInfo, NoLog, WriteMetaJson, AppendUrlParams, ChangeMpd, ConcurrentDownload, Headers, SubOnly, SubtitleFormat, AutoSubtitleFix,
             FFmpegBinaryPath,
             LogLevel, UILanguage, UrlProcessorArgs, Keys, KeyTextFile, DecryptionEngine, DecryptionBinaryPath, UseShakaPackager, MP4RealTimeDecryption,
             MaxSpeed,

--- a/src/N_m3u8DL-RE/CommandLine/CommandInvoker.cs
+++ b/src/N_m3u8DL-RE/CommandLine/CommandInvoker.cs
@@ -58,6 +58,8 @@ internal static partial class CommandInvoker
     private static readonly Option<bool> CheckSegmentsCount = new Option<bool>("--check-segments-count") { Description = ResString.cmd_checkSegmentsCount }.WithDefault(true);
     private static readonly Option<bool> WriteMetaJson = new Option<bool>("--write-meta-json") { Description = ResString.cmd_writeMetaJson }.WithDefault(true);
     private static readonly Option<bool> AppendUrlParams = new Option<bool>("--append-url-params") { Description = ResString.cmd_appendUrlParams }.WithDefault(false);
+    private static readonly Option<bool> ChangeMpd = new Option<bool>("--change-mpd") { Description = "Write downloaded MPD to raw.mpd, wait for replacement, then continue." }.WithDefault(false);
+    private static readonly Option<Dictionary<string, string>?> ChangeHost = new("--change-host") { HelpName = "OLD|NEW", Arity = ArgumentArity.OneOrMore, AllowMultipleArgumentsPerToken = false, Description = "Rewrite request host from OLD to NEW while keeping Host header as OLD.", CustomParser = ParseChangeHosts };
     private static readonly Option<bool> MP4RealTimeDecryption = new Option<bool>("--mp4-real-time-decryption") { Description = ResString.cmd_MP4RealTimeDecryption }.WithDefault(false);
     private static readonly Option<bool> UseShakaPackager = new Option<bool>("--use-shaka-packager") { Hidden = true, Description = ResString.cmd_useShakaPackager }.WithDefault(false);
     private static readonly Option<DecryptEngine> DecryptionEngine = new ("--decryption-engine") { Description = ResString.cmd_decryptionEngine, DefaultValueFactory = _ => DecryptEngine.MP4DECRYPT };
@@ -498,6 +500,24 @@ internal static partial class CommandInvoker
         return OtherUtil.SplitHeaderArrayToDic(array);
     }
 
+    private static Dictionary<string, string>? ParseChangeHosts(ArgumentResult result)
+    {
+        var dic = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var token in result.Tokens.Select(t => t.Value))
+        {
+            var parts = token.Split('|', 2, StringSplitOptions.TrimEntries);
+            if (parts.Length != 2 || string.IsNullOrWhiteSpace(parts[0]) || string.IsNullOrWhiteSpace(parts[1]))
+            {
+                result.AddError($"Invalid change-host: {token}. Expected format: OLD|NEW");
+                return null;
+            }
+
+            dic[parts[0]] = parts[1];
+        }
+
+        return dic;
+    }
+
     /// <summary>
     /// 解析混流引入的外部文件
     /// </summary>
@@ -639,6 +659,8 @@ internal static partial class CommandInvoker
             SkipDownload = result.GetValue(SkipDownload),
             WriteMetaJson = result.GetValue(WriteMetaJson),
             AppendUrlParams = result.GetValue(AppendUrlParams),
+            ChangeMpd = result.GetValue(ChangeMpd),
+            ChangeHosts = result.GetValue(ChangeHost),
             SavePattern = result.GetValue(SavePattern),
             Keys = result.GetValue(Keys),
             UrlProcessorArgs = result.GetValue(UrlProcessorArgs),
@@ -730,7 +752,7 @@ internal static partial class CommandInvoker
         var rootCommand = new RootCommand(VERSION_INFO)
         {
             Input, TmpDir, SaveDir, SaveName, SavePattern, LogFilePath, BaseUrl, ThreadCount, DownloadRetryCount, HttpRequestTimeout, ForceAnsiConsole, NoAnsiColor,AutoSelect, SkipMerge, SkipDownload, CheckSegmentsCount,
-            BinaryMerge, UseFFmpegConcatDemuxer, DelAfterDone, NoDateInfo, NoLog, WriteMetaJson, AppendUrlParams, ConcurrentDownload, Headers, SubOnly, SubtitleFormat, AutoSubtitleFix,
+            BinaryMerge, UseFFmpegConcatDemuxer, DelAfterDone, NoDateInfo, NoLog, WriteMetaJson, AppendUrlParams, ChangeMpd, ChangeHost, ConcurrentDownload, Headers, SubOnly, SubtitleFormat, AutoSubtitleFix,
             FFmpegBinaryPath,
             LogLevel, UILanguage, UrlProcessorArgs, Keys, KeyTextFile, DecryptionEngine, DecryptionBinaryPath, UseShakaPackager, MP4RealTimeDecryption,
             MaxSpeed,

--- a/src/N_m3u8DL-RE/CommandLine/MyOption.cs
+++ b/src/N_m3u8DL-RE/CommandLine/MyOption.cs
@@ -133,6 +133,10 @@ internal class MyOption
     /// </summary>
     public bool AppendUrlParams { get; set; }
     /// <summary>
+    /// See: <see cref="CommandInvoker.ChangeMpd"/>.
+    /// </summary>
+    public bool ChangeMpd { get; set; }
+    /// <summary>
     /// See: <see cref="CommandInvoker.MP4RealTimeDecryption"/>.
     /// </summary>
     public bool MP4RealTimeDecryption { get; set; }

--- a/src/N_m3u8DL-RE/CommandLine/MyOption.cs
+++ b/src/N_m3u8DL-RE/CommandLine/MyOption.cs
@@ -133,6 +133,14 @@ internal class MyOption
     /// </summary>
     public bool AppendUrlParams { get; set; }
     /// <summary>
+    /// See: <see cref="CommandInvoker.ChangeMpd"/>.
+    /// </summary>
+    public bool ChangeMpd { get; set; }
+    /// <summary>
+    /// See: <see cref="CommandInvoker.ChangeHost"/>.
+    /// </summary>
+    public Dictionary<string, string>? ChangeHosts { get; set; }
+    /// <summary>
     /// See: <see cref="CommandInvoker.MP4RealTimeDecryption"/>.
     /// </summary>
     public bool MP4RealTimeDecryption { get; set; }

--- a/src/N_m3u8DL-RE/DownloadManager/HTTPLiveRecordManager.cs
+++ b/src/N_m3u8DL-RE/DownloadManager/HTTPLiveRecordManager.cs
@@ -1,4 +1,4 @@
-﻿using N_m3u8DL_RE.Column;
+using N_m3u8DL_RE.Column;
 using N_m3u8DL_RE.Common.Entity;
 using N_m3u8DL_RE.Common.Log;
 using N_m3u8DL_RE.Common.Resource;
@@ -67,12 +67,10 @@ internal class HTTPLiveRecordManager
         // 创建文件夹
         if (!Directory.Exists(saveDir)) Directory.CreateDirectory(saveDir);
 
-        using var request = new HttpRequestMessage(HttpMethod.Get, new Uri(streamSpec.Url));
+        var currentUrl = streamSpec.Url;
+        using var request = HTTPUtil.CreateRequest(HttpMethod.Get, currentUrl);
         request.Headers.ConnectionClose = false;
-        foreach (var item in DownloaderConfig.Headers)
-        {
-            request.Headers.TryAddWithoutValidation(item.Key, item.Value);
-        }
+        HTTPUtil.ApplyHeaders(request, DownloaderConfig.Headers);
         Logger.Debug(request.Headers.ToString());
 
         HttpResponseMessage? response = null;
@@ -86,17 +84,14 @@ internal class HTTPLiveRecordManager
             {
                 var redirectUrl = response.Headers.Location;
                 if (redirectUrl == null) break;
-                if (!redirectUrl.IsAbsoluteUri) redirectUrl = new Uri(request.RequestUri!, redirectUrl);
+                currentUrl = redirectUrl.IsAbsoluteUri ? redirectUrl.AbsoluteUri : new Uri(new Uri(currentUrl), redirectUrl).AbsoluteUri;
 
-                Logger.Debug($"Following redirect to: {redirectUrl}");
+                Logger.Debug($"Following redirect to: {currentUrl}");
                 response.Dispose();
 
-                var redirectRequest = new HttpRequestMessage(HttpMethod.Get, redirectUrl);
+                using var redirectRequest = HTTPUtil.CreateRequest(HttpMethod.Get, currentUrl);
                 redirectRequest.Headers.ConnectionClose = false;
-                foreach (var item in DownloaderConfig.Headers)
-                {
-                    redirectRequest.Headers.TryAddWithoutValidation(item.Key, item.Value);
-                }
+                HTTPUtil.ApplyHeaders(redirectRequest, DownloaderConfig.Headers);
 
                 response = await HttpClient.SendAsync(redirectRequest, HttpCompletionOption.ResponseHeadersRead, CancellationTokenSource.Token);
                 redirectCount++;

--- a/src/N_m3u8DL-RE/DownloadManager/SimpleLiveRecordManager2.cs
+++ b/src/N_m3u8DL-RE/DownloadManager/SimpleLiveRecordManager2.cs
@@ -753,7 +753,25 @@ internal class SimpleLiveRecordManager2
                 // Logger.WarnMarkUp($"wait {waitSec}s");
                 if (!STOP_FLAG) await Task.Delay(WAIT_SEC * 1000, CancellationTokenSource.Token);
                 // 刷新列表
-                if (!STOP_FLAG) await StreamExtractor.RefreshPlayListAsync(dic.Keys.ToList());
+                if (!STOP_FLAG)
+                {
+                    var streamSpecs = dic.Keys.ToList();
+                    await StreamExtractor.RefreshPlayListAsync(streamSpecs);
+                    var noNewSegments = StreamExtractor.ExtractorType == ExtractorType.HLS
+                        ? streamSpecs.Where(streamSpec =>
+                        {
+                            var task = dic[streamSpec];
+                            var allHasDatetime = streamSpec.Playlist!.MediaParts[0].MediaSegments.All(s => s.DateTime != null);
+                            var allSamePath = SamePathDic.TryGetValue(task.Id, out var samePath) && samePath;
+                            return !HasNewMediaSegments(streamSpec, task, allHasDatetime, allSamePath);
+                        }).ToList()
+                        : [];
+                    if (noNewSegments.Count > 0)
+                    {
+                        Logger.WarnMarkUp("No new segments found. Try refreshing url from previous url...");
+                        await StreamExtractor.RefreshPlayListFromRefreshUrlAsync(noNewSegments);
+                    }
+                }
             }
             catch (OperationCanceledException oce) when (oce.CancellationToken == CancellationTokenSource.Token)
             {
@@ -777,6 +795,27 @@ internal class SimpleLiveRecordManager2
         {
             target.Complete();
         }
+    }
+
+    private bool HasNewMediaSegments(StreamSpec streamSpec, ProgressTask task, bool allHasDatetime, bool allSamePath)
+    {
+        if (string.IsNullOrEmpty(LastFileNameDic[task.Id]) && DateTimeDic[task.Id] == 0) return true;
+
+        var dateTime = DateTimeDic[task.Id];
+        var lastName = LastFileNameDic[task.Id];
+        var segments = streamSpec.Playlist!.MediaParts[0].MediaSegments;
+        int index;
+
+        if (dateTime != 0 && segments.All(s => s.DateTime != null))
+        {
+            index = segments.FindIndex(s => GetUnixTimestamp(s.DateTime!.Value) == dateTime);
+        }
+        else
+        {
+            index = segments.FindIndex(s => GetSegmentName(s, allHasDatetime, allSamePath) == lastName);
+        }
+
+        return index == -1 || index + 1 < segments.Count;
     }
 
     private void FilterMediaSegments(StreamSpec streamSpec, ProgressTask task, bool allHasDatetime, bool allSamePath)

--- a/src/N_m3u8DL-RE/Program.cs
+++ b/src/N_m3u8DL-RE/Program.cs
@@ -195,6 +195,7 @@ internal class Program
         var parserConfig = new ParserConfig()
         {
             AppendUrlParams = option.AppendUrlParams,
+            ChangeMpd = option.ChangeMpd,
             UrlProcessorArgs = option.UrlProcessorArgs,
             BaseUrl = option.BaseUrl!,
             Headers = headers,
@@ -223,6 +224,20 @@ internal class Program
             {
                 await Task.Delay(1000);
             }
+        }
+
+        string? tmpDir = null;
+        if (option.ChangeMpd)
+        {
+            // 尝试从URL或文件读取文件名
+            if (string.IsNullOrEmpty(option.SaveName))
+            {
+                option.SaveName = OtherUtil.GetFileNameFromInput(option.Input);
+            }
+
+            // 生成文件夹
+            tmpDir = Path.Combine(option.TmpDir ?? Environment.CurrentDirectory, $"{option.SaveName ?? DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss")}");
+            parserConfig.ChangeMpdFilePath = Path.Combine(tmpDir, "raw.mpd");
         }
 
         var url = option.Input;
@@ -255,7 +270,7 @@ internal class Program
         }
 
         // 生成文件夹
-        var tmpDir = Path.Combine(option.TmpDir ?? Environment.CurrentDirectory, $"{option.SaveName ?? DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss")}");
+        tmpDir ??= Path.Combine(option.TmpDir ?? Environment.CurrentDirectory, $"{option.SaveName ?? DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss")}");
         // 记录文件
         if (option.WriteMetaJson)
         {

--- a/src/N_m3u8DL-RE/Program.cs
+++ b/src/N_m3u8DL-RE/Program.cs
@@ -192,9 +192,16 @@ internal class Program
             Logger.Extra($"User-Defined Header => {item.Key}: {item.Value}");
         }
 
+        HTTPUtil.ChangeHosts = option.ChangeHosts ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var item in HTTPUtil.ChangeHosts)
+        {
+            Logger.Extra($"ChangeHost => {item.Key}|{item.Value}");
+        }
+
         var parserConfig = new ParserConfig()
         {
             AppendUrlParams = option.AppendUrlParams,
+            ChangeMpd = option.ChangeMpd,
             UrlProcessorArgs = option.UrlProcessorArgs,
             BaseUrl = option.BaseUrl!,
             Headers = headers,
@@ -223,6 +230,20 @@ internal class Program
             {
                 await Task.Delay(1000);
             }
+        }
+
+        string? tmpDir = null;
+        if (option.ChangeMpd)
+        {
+            // 尝试从URL或文件读取文件名
+            if (string.IsNullOrEmpty(option.SaveName))
+            {
+                option.SaveName = OtherUtil.GetFileNameFromInput(option.Input);
+            }
+
+            // 生成文件夹
+            tmpDir = Path.Combine(option.TmpDir ?? Environment.CurrentDirectory, $"{option.SaveName ?? DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss")}");
+            parserConfig.ChangeMpdFilePath = Path.Combine(tmpDir, "raw.mpd");
         }
 
         var url = option.Input;
@@ -255,7 +276,7 @@ internal class Program
         }
 
         // 生成文件夹
-        var tmpDir = Path.Combine(option.TmpDir ?? Environment.CurrentDirectory, $"{option.SaveName ?? DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss")}");
+        tmpDir ??= Path.Combine(option.TmpDir ?? Environment.CurrentDirectory, $"{option.SaveName ?? DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss")}");
         // 记录文件
         if (option.WriteMetaJson)
         {

--- a/src/N_m3u8DL-RE/Util/DownloadUtil.cs
+++ b/src/N_m3u8DL-RE/Util/DownloadUtil.cs
@@ -63,16 +63,10 @@ internal static class DownloadUtil
                 ActualFilePath = path,
             };
         }
-        using var request = new HttpRequestMessage(HttpMethod.Get, new Uri(url));
+        using var request = HTTPUtil.CreateRequest(HttpMethod.Get, url);
         if (fromPosition != null || toPosition != null)
             request.Headers.Range = new(fromPosition, toPosition);
-        if (headers != null)
-        {
-            foreach (var item in headers)
-            {
-                request.Headers.TryAddWithoutValidation(item.Key, item.Value);
-            }
-        }
+        HTTPUtil.ApplyHeaders(request, headers);
         Logger.Debug(request.Headers.ToString());
         try
         {

--- a/src/N_m3u8DL-RE/Util/LargeSingleFileSplitUtil.cs
+++ b/src/N_m3u8DL-RE/Util/LargeSingleFileSplitUtil.cs
@@ -50,7 +50,8 @@ internal static class LargeSingleFileSplitUtil
     {
         try
         {
-            var request = new HttpRequestMessage(HttpMethod.Head, url);
+            using var request = HTTPUtil.CreateRequest(HttpMethod.Head, url);
+            HTTPUtil.ApplyHeaders(request, headers);
             var response = (await HTTPUtil.AppHttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead)).EnsureSuccessStatusCode();
             bool supportsRangeRequests = response.Headers.Contains("Accept-Ranges");
 
@@ -65,13 +66,8 @@ internal static class LargeSingleFileSplitUtil
 
     private static async Task<long> GetFileSizeAsync(string url, Dictionary<string, string> headers)
     {
-        using var httpRequestMessage = new HttpRequestMessage();
-        httpRequestMessage.Method = HttpMethod.Head;
-        httpRequestMessage.RequestUri = new(url);
-        foreach (var header in headers)
-        {
-            httpRequestMessage.Headers.TryAddWithoutValidation(header.Key, header.Value);
-        }
+        using var httpRequestMessage = HTTPUtil.CreateRequest(HttpMethod.Head, url);
+        HTTPUtil.ApplyHeaders(httpRequestMessage, headers);
         var response = (await HTTPUtil.AppHttpClient.SendAsync(httpRequestMessage, HttpCompletionOption.ResponseHeadersRead)).EnsureSuccessStatusCode();
         long totalSizeBytes = response.Content.Headers.ContentLength ?? 0;
 


### PR DESCRIPTION
This PR adds three related improvements:

### `--change-mpd`
- Adds `--change-mpd` to write the downloaded MPD to `raw.mpd`.
- The program pauses after saving the MPD, lets the user replace/edit `raw.mpd`, and continues after the user presses `y`.

### `--change-host "OLD|NEW"`
- Adds host rewrite support for requests.
- When a request URL host matches `OLD`, the actual request URL is rewritten to `NEW`.
- The HTTP `Host` header is kept as the original `OLD` host/authority.
- The option can be specified multiple times.

### HLS redirected playlist refresh
- Improves live HLS refresh when an initial playlist redirects from `A.m3u8` to `B.m3u8`.
- After the redirect, refreshes prefer the redirected `B.m3u8` URL first.
- If `B.m3u8` fails, returns a bad playlist, or no new segments are found, it falls back to the previous/original playlist URL to obtain a fresh redirected URL.
- This avoids refreshing the original playlist after every segment batch while still recovering from expired redirected playlists.

### Validation
- `dotnet build ./src/N_m3u8DL-RE/N_m3u8DL-RE.csproj -c Release`
- `dotnet test ./src/N_m3u8DL-RE.Tests/N_m3u8DL-RE.Tests.csproj -c Release`


---

中文说明：

本 PR 包含三个相关改动：

### `--change-mpd`
- 新增 `--change-mpd` 参数，下载 MPD 后会先写出到 `raw.mpd`。
- 程序保存 MPD 后暂停，允许用户替换或编辑 `raw.mpd`，用户按 `y` 后继续后续解析和下载流程。

### `--change-host "OLD|NEW"`
- 新增请求 Host 替换能力。
- 当请求 URL 的域名匹配 `OLD` 时，实际请求 URL 会改为 `NEW`。
- HTTP `Host` 头仍保持原始的 `OLD` 域名或 authority。
- 该参数支持指定多次。

### HLS 跳转 playlist 刷新优化
- 优化直播 HLS 场景：初始 playlist 从 `A.m3u8` 跳转到 `B.m3u8` 后，后续刷新会优先请求跳转后的 `B.m3u8`。
- 如果 `B.m3u8` 请求失败、返回无效 m3u8，或者没有发现新的 ts 分片，再回退请求上一层/原始 playlist URL，以重新获取新的跳转地址。
- 这样可以避免每下载一批分片就刷新原始 playlist，同时仍能在跳转后的 playlist 过期时自动恢复。

### 验证
- `dotnet build ./src/N_m3u8DL-RE/N_m3u8DL-RE.csproj -c Release`
- `dotnet test ./src/N_m3u8DL-RE.Tests/N_m3u8DL-RE.Tests.csproj -c Release`
