### PR TITLE
Truncate over-long segment file names to avoid filesystem errors (#650)

### DIFF
--- a/src/N_m3u8DL-RE.Tests/Util/OtherUtilTests.cs
+++ b/src/N_m3u8DL-RE.Tests/Util/OtherUtilTests.cs
@@ -1,0 +1,66 @@
+using System.Text;
+using N_m3u8DL_RE.Util;
+
+namespace N_m3u8DL_RE.Tests.Util;
+
+public class OtherUtilTests
+{
+    [Fact]
+    public void GetValidFileName_ReplacesInvalidChars()
+    {
+        Assert.Equal("a_b_c", OtherUtil.GetValidFileName("a:b*c"));
+    }
+
+    [Fact]
+    public void GetValidFileName_NoMaxLength_LeavesLongNameUntouched()
+    {
+        var input = new string('a', 1000);
+        Assert.Equal(input, OtherUtil.GetValidFileName(input));
+    }
+
+    // Issue #650: URL-derived names (e.g. YouTube DASH query strings) can exceed the
+    // filesystem's 255-byte component limit and fail to create the temp file.
+    [Fact]
+    public void GetValidFileName_WithMaxLength_TruncatesToByteBudget()
+    {
+        var input = new string('a', 1000);
+        var result = OtherUtil.GetValidFileName(input, maxLength: 200);
+        Assert.True(Encoding.UTF8.GetByteCount(result) <= 200);
+    }
+
+    [Fact]
+    public void TruncateFileName_ShortName_IsUnchanged()
+    {
+        Assert.Equal("seg_001.ts", OtherUtil.TruncateFileName("seg_001.ts", 200));
+    }
+
+    [Fact]
+    public void TruncateFileName_IsDeterministic()
+    {
+        var input = new string('x', 500);
+        Assert.Equal(OtherUtil.TruncateFileName(input, 100), OtherUtil.TruncateFileName(input, 100));
+    }
+
+    // Truncated names must stay unique so live-stream segment dedup keeps working.
+    [Fact]
+    public void TruncateFileName_DifferentLongNames_DoNotCollide()
+    {
+        var prefix = new string('p', 300);
+        var a = OtherUtil.TruncateFileName(prefix + "_segmentA", 100);
+        var b = OtherUtil.TruncateFileName(prefix + "_segmentB", 100);
+        Assert.NotEqual(a, b);
+        Assert.True(Encoding.UTF8.GetByteCount(a) <= 100);
+        Assert.True(Encoding.UTF8.GetByteCount(b) <= 100);
+    }
+
+    [Fact]
+    public void TruncateFileName_DoesNotSplitMultiByteChars()
+    {
+        // each '中' is 3 UTF-8 bytes; an odd budget must not cut one in half
+        var input = string.Concat(Enumerable.Repeat("中", 100));
+        var result = OtherUtil.TruncateFileName(input, 50);
+        Assert.True(Encoding.UTF8.GetByteCount(result) <= 50);
+        // round-trips cleanly (no replacement chars from a broken sequence)
+        Assert.DoesNotContain('�', result);
+    }
+}

--- a/src/N_m3u8DL-RE/DownloadManager/SimpleLiveRecordManager2.cs
+++ b/src/N_m3u8DL-RE/DownloadManager/SimpleLiveRecordManager2.cs
@@ -106,7 +106,9 @@ internal class SimpleLiveRecordManager2
             name = segment.Index.ToString();
         }
 
-        return name;
+        // URL 衍生的分片名(尤其是 DASH 带超长查询串的场景, 如 YouTube)可能超过文件系统
+        // 单个组件 255 字节的限制导致创建临时文件失败, 这里统一截断到安全长度。see #650
+        return OtherUtil.TruncateFileName(name, 200);
     }
 
     private void ChangeSpecInfo(StreamSpec streamSpec, List<Mediainfo> mediainfos, ref bool useAACFilter)

--- a/src/N_m3u8DL-RE/Util/OtherUtil.cs
+++ b/src/N_m3u8DL-RE/Util/OtherUtil.cs
@@ -1,5 +1,7 @@
 ﻿using N_m3u8DL_RE.Enum;
 using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace N_m3u8DL_RE.Util;
@@ -25,7 +27,7 @@ internal static partial class OtherUtil
 
     private static readonly char[] InvalidChars = "34,60,62,124,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,58,42,63,92,47"
         .Split(',').Select(s => (char)int.Parse(s)).ToArray();
-    public static string GetValidFileName(string input, string re = "_", bool filterSlash = false)
+    public static string GetValidFileName(string input, string re = "_", bool filterSlash = false, int maxLength = 0)
     {
         var title = InvalidChars.Aggregate(input, (current, invalidChar) => current.Replace(invalidChar.ToString(), re));
         if (filterSlash)
@@ -33,7 +35,38 @@ internal static partial class OtherUtil
             title = title.Replace("/", re);
             title = title.Replace("\\", re);
         }
-        return title.Trim('.');
+        title = title.Trim('.');
+        if (maxLength > 0)
+            title = TruncateFileName(title, maxLength);
+        return title;
+    }
+
+    /// <summary>
+    /// 将文件名截断到指定的最大 UTF-8 字节数, 避免超出文件系统单个路径组件 255 字节的限制。
+    /// 截断时附加一段基于完整名称的稳定短哈希, 以保证截断后的名称仍然唯一且可复现
+    /// (直播录制依赖分片名称去重, 见 SimpleLiveRecordManager2.FilterMediaSegments)。
+    /// </summary>
+    public static string TruncateFileName(string name, int maxBytes)
+    {
+        if (maxBytes <= 0 || Encoding.UTF8.GetByteCount(name) <= maxBytes)
+            return name;
+
+        var hash = Convert.ToHexString(SHA1.HashData(Encoding.UTF8.GetBytes(name)))[..8].ToLowerInvariant();
+        var suffix = "_" + hash;
+        var budget = maxBytes - suffix.Length;
+        if (budget < 0) budget = 0;
+
+        // 按 Rune 累加, 避免在多字节字符(或代理对)中间截断
+        var sb = new StringBuilder();
+        var used = 0;
+        foreach (var rune in name.EnumerateRunes())
+        {
+            if (used + rune.Utf8SequenceLength > budget) break;
+            used += rune.Utf8SequenceLength;
+            sb.Append(rune.ToString());
+        }
+
+        return sb.Append(suffix).ToString();
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem

`OtherUtil.GetValidFileName` sanitizes invalid characters but **never caps length**. When a live segment name is derived from the URL, it can exceed the filesystem's **255-byte per-component limit** and crash:

> The filename, directory name, or volume label syntax is incorrect

This is reproducible with DASH live sources that carry very long query strings — e.g. **YouTube** (closes #650), where `SimpleLiveRecordManager2.GetSegmentName` builds the name from `segment.Url.Split('?').Last()`, then `Path.Combine(tmpDir, filename + ".{ext}.tmp")` fails to create the file.

## Fix

- `GetValidFileName` gains an optional `maxLength`.
- `SimpleLiveRecordManager2.GetSegmentName` caps segment names to a safe byte budget (200).

Truncation is **byte-aware** (`Rune`-based, never splits a multi-byte character) and appends a **stable short hash** of the full name:

```csharp
var hash = Convert.ToHexString(SHA1.HashData(Encoding.UTF8.GetBytes(name)))[..8].ToLowerInvariant();
```

The hash matters: live recording de-duplicates segments across playlist refreshes by comparing `GetSegmentName` results (`FilterMediaSegments`, `SimpleLiveRecordManager2.cs:748`). A naive prefix truncation would make distinct segments that share a long common prefix collide, breaking dedup and overwriting earlier data. The hash keeps truncated names unique and reproducible. Names already within budget are returned unchanged (no behaviour change for the common case).

## Tests

Adds `OtherUtilTests` covering: invalid-char replacement, no-cap default, byte-budget enforcement, determinism, no-collision between different long names, and multi-byte safety. All tests pass (`dotnet test`): **18 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)