### PR TITLE
Use millisecond timestamps for live segment names to prevent overwrite (#751)

### DIFF
--- a/src/N_m3u8DL-RE/DownloadManager/SimpleLiveRecordManager2.cs
+++ b/src/N_m3u8DL-RE/DownloadManager/SimpleLiveRecordManager2.cs
@@ -67,13 +67,14 @@ internal class SimpleLiveRecordManager2
     }
 
     /// <summary>
-    /// 获取时间戳
+    /// 获取时间戳(毫秒)。使用毫秒而非秒, 避免同一秒内的多个分片(如低延迟HLS或带亚秒
+    /// PROGRAM-DATE-TIME的直播源)生成相同的文件名而互相覆盖, 导致录制内容丢失。see #751
     /// </summary>
     /// <param name="dateTime"></param>
     /// <returns></returns>
     private long GetUnixTimestamp(DateTime dateTime)
     {
-        return new DateTimeOffset(dateTime.ToUniversalTime()).ToUnixTimeSeconds();
+        return new DateTimeOffset(dateTime.ToUniversalTime()).ToUnixTimeMilliseconds();
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem

When recording an HLS live stream that carries `PROGRAM-DATE-TIME`, `SimpleLiveRecordManager2.GetSegmentName` names each temp segment file by its timestamp:

```csharp
name = GetUnixTimestamp(segment.DateTime!.Value).ToString();
```

But `GetUnixTimestamp` truncates to **whole seconds** (`ToUnixTimeSeconds`), while `segment.DateTime` is parsed from `PROGRAM-DATE-TIME` with **sub-second precision** (`HLSExtractor`: `segment.DateTime = DateTime.Parse(...)`).

So when a stream has more than one segment per second — low-latency HLS, or any source whose `PROGRAM-DATE-TIME` advances by less than 1 second — two segments get the **same** file name. The path is `Path.Combine(tmpDir, filename + ".{ext}.tmp")`, so the later download **overwrites** the earlier file. `FileDic` then has two distinct segments pointing at one file, and the `Index`-ordered merge reads duplicated content — losing data and corrupting the output.

This matches the report in #751 (a one-hour `--live-pipe-mux` recording that kept only ~30 minutes, with later segments overwriting earlier ones and a corrupt muxed `.ts`). A second user confirmed the same behaviour and suggested millisecond-resolution names.

## Fix

Switch `GetUnixTimestamp` to `ToUnixTimeMilliseconds()`.

The helper has exactly three consumers, all in this file:
1. the segment file name (`GetSegmentName`),
2. the dedup boundary store (`DateTimeDic`),
3. the dedup boundary compare (`FilterMediaSegments`).

They all go through this one method, so they stay internally consistent — the cross-refresh de-duplication keeps working (still an exact match, since `PROGRAM-DATE-TIME` is identical across refreshes), just at finer resolution. The final merge orders by `segment.Index`, not by file name, so the name format change is safe.

## Notes

- No new unit test: `GetUnixTimestamp`/`GetSegmentName` are private instance members and the change itself is a single BCL call, so there's no clean seam to assert against without a refactor.
- Residual edge case: a source that emits sub-second segments but only **whole-second** `PROGRAM-DATE-TIME` values still can't be disambiguated by time alone; that information simply isn't present in the playlist. Millisecond resolution fixes the common case (sub-second PDT) reported here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #751