### PR TITLE
Detect HLS live stream end (#EXT-X-ENDLIST) and stop recording gracefully

### DIFF
--- a/src/N_m3u8DL-RE.Common/Resource/ResString.cs
+++ b/src/N_m3u8DL-RE.Common/Resource/ResString.cs
@@ -99,6 +99,7 @@ public static class ResString
     public static string liveLimit => GetText("liveLimit");
     public static string realTimeDecMessage => GetText("realTimeDecMessage");
     public static string liveLimitReached => GetText("liveLimitReached");
+    public static string liveStreamEnded => GetText("liveStreamEnded");
     public static string saveName => GetText("saveName");
     public static string taskStartAt => GetText("taskStartAt");
     public static string namedPipeCreated => GetText("namedPipeCreated");

--- a/src/N_m3u8DL-RE.Common/Resource/StaticText.cs
+++ b/src/N_m3u8DL-RE.Common/Resource/StaticText.cs
@@ -772,6 +772,12 @@ internal static class StaticText
             zhTW: "到達直播錄製上限，即將停止錄製",
             enUS: "Live recording limit reached, will stop recording soon"
         ),
+        ["liveStreamEnded"] = new TextContainer
+        (
+            zhCN: "直播已结束，即将停止录制",
+            zhTW: "直播已結束，即將停止錄製",
+            enUS: "Live stream ended, will stop recording soon"
+        ),
         ["saveName"] = new TextContainer
         (
             zhCN: "保存文件名: ",

--- a/src/N_m3u8DL-RE/DownloadManager/SimpleLiveRecordManager2.cs
+++ b/src/N_m3u8DL-RE/DownloadManager/SimpleLiveRecordManager2.cs
@@ -36,6 +36,7 @@ internal class SimpleLiveRecordManager2
     ConcurrentDictionary<int, BufferBlock<List<MediaSegment>>> BlockDic = new(); // 各流的Block
     ConcurrentDictionary<int, bool> SamePathDic = new(); // 各流是否allSamePath
     ConcurrentDictionary<int, bool> RecordLimitReachedDic = new(); // 各流是否达到上限
+    ConcurrentDictionary<int, bool> LiveEndDic = new(); // 各流是否已结束直播(出现ENDLIST)
     ConcurrentDictionary<int, string> LastFileNameDic = new(); // 上次下载的文件名
     ConcurrentDictionary<int, long> MaxIndexDic = new(); // 最大Index
     ConcurrentDictionary<int, long> DateTimeDic = new(); // 上次下载的dateTime
@@ -667,8 +668,8 @@ internal class SimpleLiveRecordManager2
                 var streamSpec = dic.Key;
                 var task = dic.Value;
 
-                // 达到上限时 不需要刷新了
-                if (RecordLimitReachedDic[task.Id])
+                // 达到上限 或 该流直播已结束时 不需要刷新了
+                if (RecordLimitReachedDic[task.Id] || LiveEndDic[task.Id])
                     return;
 
                 var allHasDatetime = streamSpec.Playlist!.MediaParts[0].MediaSegments.All(s => s.DateTime != null);
@@ -700,10 +701,25 @@ internal class SimpleLiveRecordManager2
                     RecordLimitReachedDic[task.Id] = true;
                 }
 
+                // 检测直播是否结束 (出现 #EXT-X-ENDLIST 后 HLSExtractor 会将 IsLive 置为 false)
+                // 此处在上方推送完最后一批片段之后再标记 避免漏掉收尾片段
+                if (!STOP_FLAG && streamSpec.Playlist!.IsLive == false)
+                {
+                    LiveEndDic[task.Id] = true;
+                }
+
                 // 检测时长限制
                 if (!STOP_FLAG && RecordLimitReachedDic.Values.All(x => x))
                 {
                     Logger.WarnMarkUp($"[darkorange3_1]{ResString.liveLimitReached}[/]");
+                    STOP_FLAG = true;
+                    CancellationTokenSource.Cancel();
+                }
+
+                // 检测直播结束 所有流都已结束(或达到上限)时优雅停止 让消费者收尾混流
+                if (!STOP_FLAG && RecordLimitReachedDic.Keys.All(id => RecordLimitReachedDic[id] || LiveEndDic[id]))
+                {
+                    Logger.WarnMarkUp($"[darkorange3_1]{ResString.liveStreamEnded}[/]");
                     STOP_FLAG = true;
                     CancellationTokenSource.Cancel();
                 }
@@ -730,6 +746,13 @@ internal class SimpleLiveRecordManager2
                     target.Complete();
                 }
             }
+        }
+
+        // 循环结束(直播结束/达到上限/异常) 标记所有Block完成
+        // 确保即使最后一次刷新没有新片段 消费者也能被唤醒并收尾混流
+        foreach (var target in BlockDic.Values)
+        {
+            target.Complete();
         }
     }
 
@@ -837,6 +860,7 @@ internal class SimpleLiveRecordManager2
                 }
                 LastFileNameDic[task.Id] = "";
                 RecordLimitReachedDic[task.Id] = false;
+                LiveEndDic[task.Id] = false;
                 DateTimeDic[task.Id] = 0L;
                 RecordedDurDic[task.Id] = 0;
                 RefreshedDurDic[task.Id] = 0;


### PR DESCRIPTION
## Problem

For HLS **live** playlists that include all segments from the start (rewindable lives, e.g. weverse.io), N_m3u8DL-RE keeps refreshing the playlist forever even after the stream ends and the playlist gains `#EXT-X-ENDLIST`. It never detects the end, never finishes, and never muxes. Downloading the same playlist *after* the live ended works fine.

## Root cause

The live producer loop `SimpleLiveRecordManager2.PlayListProduceAsync` is `while (!STOP_FLAG)` and only sets `STOP_FLAG` when a record-time limit is reached or an exception is thrown. It never checks `streamSpec.Playlist.IsLive`, even though the HLS parser sets it on every refresh:

```
// src/N_m3u8DL-RE.Parser/Extractor/HLSExtractor.cs:435
playlist.IsLive = !isEndlist;
```

After `RefreshPlayListAsync` re-parses an ended playlist, `IsLive` becomes `false`, but the loop ignores it and refreshes indefinitely.

## Fix

- Added a per-task `LiveEndDic` flag, mirroring the existing `RecordLimitReachedDic` pattern.
- Each iteration first sends the current playlist's (filtered) segments, **then** marks a stream ended when its refreshed playlist is no longer live (`Playlist.IsLive == false`), so the final batch of segments is never skipped.
- When **all** selected streams have ended (or hit the record limit), `STOP_FLAG` is set and the wait is cancelled. Streams already ended/limit-reached are skipped on refresh so they don't block others; `IsLive` may legitimately differ per stream.
- After the producer loop exits, all `BlockDic` blocks are `Complete()`d so the consumer `RecordStreamAsync` drains the remaining segments and muxes the output — even when the final ENDLIST refresh adds no new segments (which would otherwise leave the consumer blocked on `OutputAvailableAsync`).
- The existing record-limit stop path is unchanged.

A new resource string `liveStreamEnded` was added (zh-CN / zh-TW / en-US) following the existing `liveLimitReached` pattern.

## Testing

This live-recording loop is a private async method that needs full download config, so it isn't cleanly unit-testable (consistent with the project's other live-recording fixes), so no new unit test is added. The build passes with 0 errors and the existing test suite stays green (28/28).

Fixes #594

🤖 Generated with [Claude Code](https://claude.com/claude-code)