### PR TITLE
Apply --ad-keyword filtering to live streams (and EXT-X-MAP init)

### DIFF
--- a/src/N_m3u8DL-RE.Tests/Util/FilterUtilTests.cs
+++ b/src/N_m3u8DL-RE.Tests/Util/FilterUtilTests.cs
@@ -1,0 +1,61 @@
+using System.Text.RegularExpressions;
+using N_m3u8DL_RE.Common.Entity;
+using N_m3u8DL_RE.Util;
+using Shouldly;
+
+namespace N_m3u8DL_RE.Tests.Util;
+
+public class FilterUtilTests
+{
+    [Fact]
+    public void ParseAdKeywords_NullKeywords_ReturnsEmptyList()
+    {
+        FilterUtil.ParseAdKeywords(null).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ParseAdKeywords_CompilesEachKeyword()
+    {
+        var regList = FilterUtil.ParseAdKeywords(["/ad/", @"ccode=\d+"]);
+        regList.Count.ShouldBe(2);
+    }
+
+    [Theory]
+    [InlineData("https://cdn.example.com/ad/seg1.ts", true)]
+    [InlineData("https://cdn.example.com/video/seg1.ts", false)]
+    public void IsAd_MatchesAgainstKeywordRegexes(string url, bool expected)
+    {
+        var regList = FilterUtil.ParseAdKeywords(["/ad/", "advert"]);
+        FilterUtil.IsAd(url, regList).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void CleanAdSegments_RemovesMatchingSegments()
+    {
+        var segments = new List<MediaSegment>
+        {
+            new() { Index = 0, Url = "https://cdn.example.com/video/0.ts" },
+            new() { Index = 1, Url = "https://cdn.example.com/ad/1.ts" },
+            new() { Index = 2, Url = "https://cdn.example.com/video/2.ts" },
+        };
+        var regList = FilterUtil.ParseAdKeywords(["/ad/"]);
+
+        var result = FilterUtil.CleanAdSegments(segments, regList);
+
+        result.Count.ShouldBe(2);
+        result.ShouldAllBe(s => !s.Url.Contains("/ad/"));
+    }
+
+    [Fact]
+    public void CleanAdSegments_EmptyRegexList_ReturnsInputUnchanged()
+    {
+        var segments = new List<MediaSegment>
+        {
+            new() { Index = 0, Url = "https://cdn.example.com/ad/0.ts" },
+        };
+
+        var result = FilterUtil.CleanAdSegments(segments, []);
+
+        result.ShouldBeSameAs(segments);
+    }
+}

--- a/src/N_m3u8DL-RE/DownloadManager/SimpleLiveRecordManager2.cs
+++ b/src/N_m3u8DL-RE/DownloadManager/SimpleLiveRecordManager2.cs
@@ -15,6 +15,7 @@ using Spectre.Console;
 using System.Collections.Concurrent;
 using System.IO.Pipes;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks.Dataflow;
 using N_m3u8DL_RE.Enum;
 
@@ -40,6 +41,7 @@ internal class SimpleLiveRecordManager2
     ConcurrentDictionary<int, long> MaxIndexDic = new(); // 最大Index
     ConcurrentDictionary<int, long> DateTimeDic = new(); // 上次下载的dateTime
     CancellationTokenSource CancellationTokenSource = new(); // 取消Wait
+    List<Regex> AdKeywordRegexList = []; // 广告关键字正则（直播刷新时复用）
 
     private readonly Lock lockObj = new();
     TimeSpan? audioStart = null;
@@ -681,6 +683,12 @@ internal class SimpleLiveRecordManager2
                 // 过滤不需要下载的片段
                 FilterMediaSegments(streamSpec, task, allHasDatetime, SamePathDic[task.Id]);
                 var newList = streamSpec.Playlist!.MediaParts[0].MediaSegments;
+                // 过滤广告分片（在更新去重边界/时长记录之前剔除，避免污染统计）
+                if (AdKeywordRegexList.Count > 0)
+                {
+                    newList = FilterUtil.CleanAdSegments(newList, AdKeywordRegexList);
+                    streamSpec.Playlist!.MediaParts[0].MediaSegments = newList;
+                }
                 if (newList.Count > 0)
                 {
                     task.MaxValue += newList.Count;
@@ -780,6 +788,12 @@ internal class SimpleLiveRecordManager2
         ConcurrentDictionary<StreamSpec, bool?> Results = new();
         // 同步流
         FilterUtil.SyncStreams(SelectedSteams, takeLastCount);
+        // 初始化广告关键字正则，仅在启动时记录一次（直播刷新时复用，避免每次刷新刷屏）
+        AdKeywordRegexList = FilterUtil.ParseAdKeywords(DownloaderConfig.MyOptions.AdKeywords);
+        foreach (var reg in AdKeywordRegexList)
+        {
+            Logger.InfoMarkUp($"{ResString.customAdKeywordsFound}[Cyan underline]{reg}[/]");
+        }
         // 设置等待时间
         if (WAIT_SEC == 0)
         {

--- a/src/N_m3u8DL-RE/Util/FilterUtil.cs
+++ b/src/N_m3u8DL-RE/Util/FilterUtil.cs
@@ -240,8 +240,8 @@ public static class FilterUtil
     public static void CleanAd(List<StreamSpec> selectedSteams, string[]? keywords)
     {
         if (keywords == null) return;
-        var regList = keywords.Select(s => new Regex(s)).ToList();
-        foreach ( var reg in regList)
+        var regList = ParseAdKeywords(keywords);
+        foreach (var reg in regList)
         {
             Logger.InfoMarkUp($"{ResString.customAdKeywordsFound}[Cyan underline]{reg}[/]");
         }
@@ -255,16 +255,22 @@ public static class FilterUtil
             foreach (var part in stream.Playlist.MediaParts)
             {
                 // 没有找到广告分片
-                if (part.MediaSegments.All(x => regList.All(reg => !reg.IsMatch(x.Url))))
+                if (part.MediaSegments.All(x => !IsAd(x.Url, regList)))
                 {
                     continue;
                 }
                 // 找到广告分片 清理
-                part.MediaSegments = part.MediaSegments.Where(x => regList.All(reg => !reg.IsMatch(x.Url))).ToList();
+                part.MediaSegments = CleanAdSegments(part.MediaSegments, regList);
             }
 
             // 清理已经为空的 part
             stream.Playlist.MediaParts = stream.Playlist.MediaParts.Where(x => x.MediaSegments.Count > 0).ToList();
+
+            // 如果 #EXT-X-MAP 初始化分片本身命中广告关键字，也一并清除
+            if (stream.Playlist.MediaInit != null && IsAd(stream.Playlist.MediaInit.Url, regList))
+            {
+                stream.Playlist.MediaInit = null;
+            }
 
             var countAfter = stream.SegmentsCount;
 
@@ -273,5 +279,35 @@ public static class FilterUtil
                 Logger.WarnMarkUp("[grey]{} segments => {} segments[/]", countBefore, countAfter);
             }
         }
+    }
+
+    /// <summary>
+    /// 将广告关键字编译为正则表达式列表（供 VOD 与直播复用）
+    /// </summary>
+    /// <param name="keywords"></param>
+    public static List<Regex> ParseAdKeywords(string[]? keywords)
+    {
+        return keywords == null ? [] : keywords.Select(s => new Regex(s)).ToList();
+    }
+
+    /// <summary>
+    /// 判断给定的URL是否命中任意一个广告关键字正则
+    /// </summary>
+    /// <param name="url"></param>
+    /// <param name="regList"></param>
+    public static bool IsAd(string url, IEnumerable<Regex> regList)
+    {
+        return regList.Any(reg => reg.IsMatch(url));
+    }
+
+    /// <summary>
+    /// 从分片列表中剔除命中广告关键字的分片，返回过滤后的新列表
+    /// </summary>
+    /// <param name="segments"></param>
+    /// <param name="regList"></param>
+    public static List<MediaSegment> CleanAdSegments(List<MediaSegment> segments, List<Regex> regList)
+    {
+        if (regList.Count == 0) return segments;
+        return segments.Where(x => !IsAd(x.Url, regList)).ToList();
     }
 }


### PR DESCRIPTION
## Problem

`--ad-keyword <regex...>` is documented to drop ad segments whose URL matches any of the given regexes. It works for VOD downloads but does **nothing** for live streams (#894, #900). It also did not consider the `#EXT-X-MAP` init segment (#307).

## Root cause

Ad filtering lives in `FilterUtil.CleanAd(...)` but is called from exactly **one** place: `Program.cs:345` — which is on the **VOD download path only**. The live recording manager `SimpleLiveRecordManager2` never applied ad filtering. Because live re-fetches the playlist on every refresh, newly-fetched ad segments were never dropped.

## Fix

- **Reusable helpers** in `FilterUtil`: extracted `ParseAdKeywords(string[]?)`, `IsAd(string, IEnumerable<Regex>)`, and `CleanAdSegments(List<MediaSegment>, List<Regex>)` so the live path can share the precompiled regex list. The existing VOD `CleanAd` behavior is unchanged, including the per-keyword `ResString.customAdKeywordsFound` logging.
- **Live path**: in `SimpleLiveRecordManager2.PlayListProduceAsync`, the freshly-fetched segments are filtered through `CleanAdSegments` **before** the dedup-boundary / recorded-duration bookkeeping (`LastFileNameDic` / `DateTimeDic` / `RefreshedDurDic`), so dropped ads don't corrupt the dedup boundary or duration accounting. If nothing remains after filtering, it's treated like an empty refresh. The regex list is built **once** at startup and the active keywords are logged **once** (no per-refresh log spam).
- **`#EXT-X-MAP` (#307)**: the parser stores the init segment as a single `Playlist.MediaInit`. If an ad's `#EXT-X-MAP` init URL itself matches an ad keyword, `CleanAd` now clears `MediaInit` so the ad init segment is not downloaded. This is the safe, scoped portion of the EXT-X-MAP case; mid-playlist init switching is already handled by the parser's existing `hasAd` logic.

## Tests

Added `FilterUtilTests` covering `ParseAdKeywords`, `IsAd`, and `CleanAdSegments` (including the empty-regex passthrough). The live producer loop is not cleanly unit-testable, so it is not tested directly. Build passes with 0 errors; full test suite green (34 passed).

Fixes #894
Fixes #900
Fixes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)