### PR TITLE
docs: document all stream select/drop sub-keys in --morehelp (fixes #112)

### DIFF
--- a/src/N_m3u8DL-RE.Common/Resource/StaticText.cs
+++ b/src/N_m3u8DL-RE.Common/Resource/StaticText.cs
@@ -504,16 +504,30 @@ internal static class StaticText
         ),
         ["cmd_dropVideo"] = new TextContainer
         (
-            zhCN: "通过正则表达式去除符合要求的视频流.",
-            zhTW: "通過正則表達式去除符合要求的影片串流.",
-            enUS: "Drop video streams by regular expressions."
+            zhCN: "通过正则表达式去除符合要求的视频流. 支持与 --select-video 相同的参数, 输入 \"--morehelp select-video\" 以查看详细信息",
+            zhTW: "通過正則表達式去除符合要求的影片串流. 支援與 --select-video 相同的參數, 輸入 \"--morehelp select-video\" 以查看詳細訊息",
+            enUS: "Drop video streams by regular expressions. Accepts the same options as --select-video, use \"--morehelp select-video\" for more details"
         ),
         ["cmd_selectVideo_more"] = new TextContainer
         (
-            zhCN: "通过正则表达式选择符合要求的视频流. 你能够以:分隔形式指定如下参数:\r\n\r\n" +
-                  "id=REGEX:lang=REGEX:name=REGEX:codecs=REGEX:res=REGEX:frame=REGEX\r\n" +
-                  "segsMin=number:segsMax=number:ch=REGEX:range=REGEX:url=REGEX\r\n" +
-                  "plistDurMin=hms:plistDurMax=hms:bwMin=int:bwMax=int:role=string:for=FOR\r\n\r\n" +
+            zhCN: "通过正则表达式选择符合要求的视频流. 你能够以:分隔形式指定如下参数.\r\n" +
+                  "同样的参数也适用于 --select-audio/-sa, --select-subtitle/-ss 以及对应的 --drop-video/--drop-audio/--drop-subtitle 选项.\r\n\r\n" +
+                  "* id=REGEX: 按 GroupId 匹配\r\n" +
+                  "* lang=REGEX: 按语言代码匹配\r\n" +
+                  "* name=REGEX: 按名称匹配\r\n" +
+                  "* codecs=REGEX: 按编码匹配 (如 hvc1, avc1, mp4a)\r\n" +
+                  "* res=REGEX: 按分辨率匹配 (如 1920*, 3840*)\r\n" +
+                  "* frame=REGEX: 按帧率匹配\r\n" +
+                  "* channel=REGEX: 按音频声道数匹配 (如 6, 2)\r\n" +
+                  "* range=REGEX: 按视频动态范围匹配 (如 SDR, HDR, PQ)\r\n" +
+                  "* url=REGEX: 按分片URL匹配\r\n" +
+                  "* segsMin=number: 仅保留分片数 >= number 的流\r\n" +
+                  "* segsMax=number: 仅保留分片数 <= number 的流\r\n" +
+                  "* plistDurMin=hms: 仅保留时长 >= hms 的流 (如 1h20m30s, 90s)\r\n" +
+                  "* plistDurMax=hms: 仅保留时长 <= hms 的流\r\n" +
+                  "* bwMin=int: 仅保留码率 >= int Kbps 的流\r\n" +
+                  "* bwMax=int: 仅保留码率 <= int Kbps 的流\r\n" +
+                  "* role=string: 按 DASH role 匹配 (Subtitle, Main, Alternate, Supplementary, Commentary, Dub, Description, Sign, Metadata, ForcedSubtitle)\r\n" +
                   "* for=FOR: 选择方式. best[number], worst[number], all (默认: best)\r\n\r\n" +
                   "例如: \r\n" +
                   "# 选择最佳视频\r\n" +
@@ -524,11 +538,27 @@ internal static class StaticText
                   "-sv plistDurMin=\"1h20m30s\":for=best\r\n" +
                   "-sv role=\"main\":for=best\r\n" +
                   "# 选择码率在800Kbps至1Mbps之间的视频\r\n" +
-                  "-sv bwMin=800:bwMax=1000\r\n",
-            zhTW: "通過正則表達式選擇符合要求的影片軌. 你能夠以:分隔形式指定如下參數:\r\n\r\n" +
-                  "id=REGEX:lang=REGEX:name=REGEX:codecs=REGEX:res=REGEX:frame=REGEX\r\n" +
-                  "segsMin=number:segsMax=number:ch=REGEX:range=REGEX:url=REGEX\r\n" +
-                  "plistDurMin=hms:plistDurMax=hms:bwMin=int:bwMax=int:role=string:for=FOR\r\n\r\n" +
+                  "-sv bwMin=800:bwMax=1000\r\n" +
+                  "# 去除分片数不超过2的字幕流 (如 trick-play/广告列表)\r\n" +
+                  "-ds segsMax=2:for=all --auto-select\r\n",
+            zhTW: "通過正則表達式選擇符合要求的影片軌. 你能夠以:分隔形式指定如下參數.\r\n" +
+                  "同樣的參數也適用於 --select-audio/-sa, --select-subtitle/-ss 以及對應的 --drop-video/--drop-audio/--drop-subtitle 選項.\r\n\r\n" +
+                  "* id=REGEX: 按 GroupId 匹配\r\n" +
+                  "* lang=REGEX: 按語言代碼匹配\r\n" +
+                  "* name=REGEX: 按名稱匹配\r\n" +
+                  "* codecs=REGEX: 按編碼匹配 (如 hvc1, avc1, mp4a)\r\n" +
+                  "* res=REGEX: 按解析度匹配 (如 1920*, 3840*)\r\n" +
+                  "* frame=REGEX: 按影格率匹配\r\n" +
+                  "* channel=REGEX: 按音訊聲道數匹配 (如 6, 2)\r\n" +
+                  "* range=REGEX: 按影片動態範圍匹配 (如 SDR, HDR, PQ)\r\n" +
+                  "* url=REGEX: 按分片URL匹配\r\n" +
+                  "* segsMin=number: 僅保留分片數 >= number 的串流\r\n" +
+                  "* segsMax=number: 僅保留分片數 <= number 的串流\r\n" +
+                  "* plistDurMin=hms: 僅保留時長 >= hms 的串流 (如 1h20m30s, 90s)\r\n" +
+                  "* plistDurMax=hms: 僅保留時長 <= hms 的串流\r\n" +
+                  "* bwMin=int: 僅保留碼率 >= int Kbps 的串流\r\n" +
+                  "* bwMax=int: 僅保留碼率 <= int Kbps 的串流\r\n" +
+                  "* role=string: 按 DASH role 匹配 (Subtitle, Main, Alternate, Supplementary, Commentary, Dub, Description, Sign, Metadata, ForcedSubtitle)\r\n" +
                   "* for=FOR: 選擇方式. best[number], worst[number], all (默認: best)\r\n\r\n" +
                   "例如: \r\n" +
                   "# 選擇最佳影片\r\n" +
@@ -539,12 +569,28 @@ internal static class StaticText
                   "-sv plistDurMin=\"1h20m30s\":for=best\r\n" +
                   "-sv role=\"main\":for=best\r\n" +
                   "# 選擇碼率在800Kbps至1Mbps之間的影片\r\n" +
-                  "-sv bwMin=800:bwMax=1000\r\n",
-            enUS: "Select video streams by regular expressions. OPTIONS is a colon separated list of:\r\n\r\n" +
-                  "id=REGEX:lang=REGEX:name=REGEX:codecs=REGEX:res=REGEX:frame=REGEX\r\n" +
-                  "segsMin=number:segsMax=number:ch=REGEX:range=REGEX:url=REGEX\r\n" +
-                  "plistDurMin=hms:plistDurMax=hms:bwMin=int:bwMax=int:role=string:for=FOR\r\n\r\n" +
-                  "* for=FOR: Select type. best[number], worst[number], all (Default: best)\r\n\r\n" +
+                  "-sv bwMin=800:bwMax=1000\r\n" +
+                  "# 去除分片數不超過2的字幕串流 (如 trick-play/廣告列表)\r\n" +
+                  "-ds segsMax=2:for=all --auto-select\r\n",
+            enUS: "Select video streams by regular expressions. OPTIONS is a colon (:) separated list of the following sub-keys.\r\n" +
+                  "The same sub-keys also work for --select-audio/-sa, --select-subtitle/-ss and the matching --drop-video/--drop-audio/--drop-subtitle options.\r\n\r\n" +
+                  "* id=REGEX: match by group/stream id\r\n" +
+                  "* lang=REGEX: match by language code\r\n" +
+                  "* name=REGEX: match by stream name\r\n" +
+                  "* codecs=REGEX: match by codecs (e.g. hvc1, avc1, mp4a)\r\n" +
+                  "* res=REGEX: match by resolution (e.g. 1920*, 3840*)\r\n" +
+                  "* frame=REGEX: match by frame rate\r\n" +
+                  "* channel=REGEX: match by audio channel count (e.g. 6, 2)\r\n" +
+                  "* range=REGEX: match by video range (e.g. SDR, HDR, PQ)\r\n" +
+                  "* url=REGEX: match by segment url\r\n" +
+                  "* segsMin=number: keep streams with at least number segments\r\n" +
+                  "* segsMax=number: keep streams with at most number segments\r\n" +
+                  "* plistDurMin=hms: keep streams whose playlist duration >= hms (e.g. 1h20m30s, 90s)\r\n" +
+                  "* plistDurMax=hms: keep streams whose playlist duration <= hms\r\n" +
+                  "* bwMin=int: keep streams with bandwidth >= int Kbps\r\n" +
+                  "* bwMax=int: keep streams with bandwidth <= int Kbps\r\n" +
+                  "* role=string: match by DASH role (Subtitle, Main, Alternate, Supplementary, Commentary, Dub, Description, Sign, Metadata, ForcedSubtitle)\r\n" +
+                  "* for=FOR: how many of the matched streams to keep. best[number], worst[number], all (Default: best)\r\n\r\n" +
                   "Examples: \r\n" +
                   "# select best video\r\n" +
                   "-sv best\r\n" +
@@ -554,7 +600,9 @@ internal static class StaticText
                   "-sv plistDurMin=\"1h20m30s\":for=best\r\n" +
                   "-sv role=\"main\":for=best\r\n" +
                   "# Select video with bandwidth between 800Kbps and 1Mbps\r\n" +
-                  "-sv bwMin=800:bwMax=1000\r\n"
+                  "-sv bwMin=800:bwMax=1000\r\n" +
+                  "# Drop subtitle streams that have at most 2 segments (e.g. trick-play/ad playlists)\r\n" +
+                  "-ds segsMax=2:for=all --auto-select\r\n"
         ),
         ["cmd_selectAudio"] = new TextContainer
         (
@@ -564,9 +612,9 @@ internal static class StaticText
         ),
         ["cmd_dropAudio"] = new TextContainer
         (
-            zhCN: "通过正则表达式去除符合要求的音频流.",
-            zhTW: "通過正則表達式去除符合要求的音軌.",
-            enUS: "Drop audio streams by regular expressions."
+            zhCN: "通过正则表达式去除符合要求的音频流. 支持与 --select-video 相同的参数, 输入 \"--morehelp select-video\" 以查看详细信息",
+            zhTW: "通過正則表達式去除符合要求的音軌. 支援與 --select-video 相同的參數, 輸入 \"--morehelp select-video\" 以查看詳細訊息",
+            enUS: "Drop audio streams by regular expressions. Accepts the same options as --select-video, use \"--morehelp select-video\" for more details"
         ),
         ["cmd_selectAudio_more"] = new TextContainer
         (
@@ -606,9 +654,9 @@ internal static class StaticText
         ),
         ["cmd_dropSubtitle"] = new TextContainer
         (
-            zhCN: "通过正则表达式去除符合要求的字幕流.",
-            zhTW: "通過正則表達式去除符合要求的字幕流.",
-            enUS: "Drop subtitle streams by regular expressions."
+            zhCN: "通过正则表达式去除符合要求的字幕流. 支持与 --select-video 相同的参数, 输入 \"--morehelp select-video\" 以查看详细信息",
+            zhTW: "通過正則表達式去除符合要求的字幕流. 支援與 --select-video 相同的參數, 輸入 \"--morehelp select-video\" 以查看詳細訊息",
+            enUS: "Drop subtitle streams by regular expressions. Accepts the same options as --select-video, use \"--morehelp select-video\" for more details"
         ),
         ["cmd_custom_range"] = new TextContainer
         (


### PR DESCRIPTION
## Problem

The stream **select/drop** filters (`-sv/-sa/-ss` and `-dv/-da/-ds`) accept a rich set of colon-separated sub-keys that are parsed in `ParseStreamFilter` (`CommandInvoker.cs`), but most of them were never documented in the program's help output. As reported in #112, useful options such as `segsMin`/`segsMax` were not listed anywhere in `--help` or `--morehelp`, so users could not discover them (e.g. `-ds segsMax=2:for=all --auto-select`).

## Changes

- Rewrote the `--morehelp select-video` reference so it documents **every** sub-key the parser actually reads, each with its purpose, value format and examples:
  `id`, `lang`, `name`, `codecs`, `res`, `frame`, `channel`, `range`, `url`, `segsMin`, `segsMax`, `plistDurMin`, `plistDurMax`, `bwMin`, `bwMax`, `role`, `for`.
- Fixed a stale key name in the old help: it listed `ch=REGEX`, but the parser reads `channel`.
- Added the issue's own example (`-ds segsMax=2:for=all --auto-select`) to the examples block.
- Updated the `--drop-video` / `--drop-audio` / `--drop-subtitle` descriptions to note they accept the same options and to point at `--morehelp select-video`.
- Applied all of the above consistently across the **zh-CN**, **zh-TW** and **en-US** locales in `StaticText.cs`.

The keys are sourced directly from the code (`ParseStreamFilter` in `src/N_m3u8DL-RE/CommandLine/CommandInvoker.cs`), and `role` values come from the `RoleType` enum.

## Rendered output (`--morehelp select-video`)

```
* id=REGEX: match by group/stream id
* lang=REGEX: match by language code
* name=REGEX: match by stream name
* codecs=REGEX: match by codecs (e.g. hvc1, avc1, mp4a)
* res=REGEX: match by resolution (e.g. 1920*, 3840*)
* frame=REGEX: match by frame rate
* channel=REGEX: match by audio channel count (e.g. 6, 2)
* range=REGEX: match by video range (e.g. SDR, HDR, PQ)
* url=REGEX: match by segment url
* segsMin=number: keep streams with at least number segments
* segsMax=number: keep streams with at most number segments
* plistDurMin=hms: keep streams whose playlist duration >= hms (e.g. 1h20m30s, 90s)
* plistDurMax=hms: keep streams whose playlist duration <= hms
* bwMin=int: keep streams with bandwidth >= int Kbps
* bwMax=int: keep streams with bandwidth <= int Kbps
* role=string: match by DASH role (Subtitle, Main, Alternate, Supplementary, Commentary, Dub, Description, Sign, Metadata, ForcedSubtitle)
* for=FOR: how many of the matched streams to keep. best[number], worst[number], all (Default: best)
```

## Testing

- `dotnet build` — 0 errors.
- `dotnet test` — 28 passed, 0 failed.
- Ran `--morehelp select-video` and confirmed the new reference renders correctly.

Fixes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)