### PR TITLE
Fix log file name race between concurrent instances

### DIFF
--- a/src/N_m3u8DL-RE.Common/Log/Logger.cs
+++ b/src/N_m3u8DL-RE.Common/Log/Logger.cs
@@ -42,14 +42,8 @@ public static partial class Logger
             var now = DateTime.Now;
             if (string.IsNullOrEmpty(LogFilePath))
             {
-                LogFilePath = Path.Combine(logDir, now.ToString("yyyy-MM-dd_HH-mm-ss-fff") + ".log");
-                int index = 1;
-                var fileName = Path.GetFileNameWithoutExtension(LogFilePath);
-                // 若文件存在则加序号
-                while (File.Exists(LogFilePath))
-                {
-                    LogFilePath = Path.Combine(Path.GetDirectoryName(LogFilePath)!, $"{fileName}-{index++}.log");
-                }
+                // 原子地占用一个唯一的日志文件名，避免多个进程在同一毫秒内选中相同文件名而冲突
+                LogFilePath = ClaimAutoLogFile(logDir, now);
             }
 
             string init = "LOG " + now.ToString("yyyy/MM/dd") + Environment.NewLine
@@ -62,6 +56,33 @@ public static partial class Logger
         catch (Exception ex)
         {
             Error($"Init log failed! {ex.Message.RemoveMarkup()}");
+        }
+    }
+
+    /// <summary>
+    /// 以独占方式创建并占用一个唯一的日志文件，返回其完整路径。
+    /// 若文件名已被占用（例如另一个进程在同一毫秒内启动）则递增序号后重试，
+    /// 从而消除“先判断存在再创建”所带来的竞态。
+    /// </summary>
+    internal static string ClaimAutoLogFile(string logDir, DateTime now)
+    {
+        var baseName = now.ToString("yyyy-MM-dd_HH-mm-ss-fff");
+        var fileName = baseName;
+        var index = 1;
+        while (true)
+        {
+            var path = Path.Combine(logDir, fileName + ".log");
+            try
+            {
+                // CreateNew 在文件已存在时会抛出 IOException，借此原子地占用文件名
+                using (new FileStream(path, FileMode.CreateNew, FileAccess.Write, FileShare.ReadWrite)) { }
+                return path;
+            }
+            catch (IOException) when (File.Exists(path))
+            {
+                // 该文件名已被占用，换一个序号继续尝试
+                fileName = $"{baseName}-{index++}";
+            }
         }
     }
 

--- a/src/N_m3u8DL-RE.Common/N_m3u8DL-RE.Common.csproj
+++ b/src/N_m3u8DL-RE.Common/N_m3u8DL-RE.Common.csproj
@@ -12,5 +12,9 @@
   <ItemGroup>
 	  <PackageReference Include="Spectre.Console" Version="0.57.1" />
   </ItemGroup>
-	
+
+  <ItemGroup>
+	  <InternalsVisibleTo Include="N_m3u8DL-RE.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/N_m3u8DL-RE.Tests/Common/Log/LoggerTests.cs
+++ b/src/N_m3u8DL-RE.Tests/Common/Log/LoggerTests.cs
@@ -1,0 +1,28 @@
+using N_m3u8DL_RE.Common.Log;
+
+namespace N_m3u8DL_RE.Tests.Common.Log;
+
+public class LoggerTests
+{
+    [Fact]
+    public void ClaimAutoLogFile_SameTimestamp_ReturnsDistinctExistingFiles()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "nm3u8dlre_log_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            // 模拟两个进程在同一毫秒内启动
+            var now = DateTime.Now;
+            var first = Logger.ClaimAutoLogFile(dir, now);
+            var second = Logger.ClaimAutoLogFile(dir, now);
+
+            Assert.NotEqual(first, second);
+            Assert.True(File.Exists(first));
+            Assert.True(File.Exists(second));
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

When two N_m3u8DL-RE instances start within the same millisecond, one fails to initialize its log file:

```
ERROR: Init log failed! The process cannot access the file '...\2025-01-24_20-51-50-924.log' because it is being used by another process.
```

## Root cause

In `Logger.InitLogFile()`, the auto log file name is a millisecond-resolution timestamp (`yyyy-MM-dd_HH-mm-ss-fff`), and uniqueness was ensured with a `while (File.Exists(...))` loop that only bumps an index when the file *already* exists. This is a classic time-of-check/time-of-use race: two processes starting in the same millisecond both observe "file does not exist", both pick the same name, and the second crashes when it opens the file the first one already holds.

## Fix

Claim the file name atomically instead of checking-then-creating. The new helper `ClaimAutoLogFile` creates the file with `FileMode.CreateNew`; if the name is already taken it catches the `IOException` and retries with the next index. Racing processes therefore deterministically end up with distinct files, eliminating the TOCTOU window. The single-instance file-name format is unchanged.

User-specified `--log-file-path` behavior is untouched (no silent renaming).

## Tests

Added `LoggerTests.ClaimAutoLogFile_SameTimestamp_ReturnsDistinctExistingFiles`, which simulates two processes claiming a log file with the same timestamp and asserts two distinct, existing files are produced. Full suite: 35 passed, 0 failed. Build: 0 errors.

Fixes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)