### PR TITLE
Fix DASH segment reference duplication causing double download (#684)

### DIFF
--- a/src/N_m3u8DL-RE.Parser/Extractor/DASHExtractor2.cs
+++ b/src/N_m3u8DL-RE.Parser/Extractor/DASHExtractor2.cs
@@ -1,5 +1,6 @@
 using N_m3u8DL_RE.Common.Entity;
 using N_m3u8DL_RE.Common.Enum;
+using N_m3u8DL_RE.Common.Log;
 using N_m3u8DL_RE.Common.Util;
 using N_m3u8DL_RE.Parser.Config;
 using N_m3u8DL_RE.Parser.Constants;
@@ -433,6 +434,20 @@ internal partial class DASHExtractor2 : IExtractor
                                 mediaSegment.Duration = duration / (double)timescale;
                                 streamSpec.Playlist.MediaParts[0].MediaSegments.Add(mediaSegment);
                             }
+                        }
+                    }
+
+                    // 去除重复分片(重叠Period/SegmentTimeline/connectivity duplicates等会导致同一分片被引用多次)
+                    // 以 URL + 字节范围 作为唯一标识, 保持原始顺序, 避免同一分片被下载两次 (#684)
+                    var _segs = streamSpec.Playlist.MediaParts[0].MediaSegments;
+                    if (_segs.Count > 1)
+                    {
+                        var _seen = new HashSet<string>();
+                        var _deduped = _segs.Where(s => _seen.Add($"{s.Url}|{s.StartRange}|{s.ExpectLength}")).ToList();
+                        if (_deduped.Count != _segs.Count)
+                        {
+                            Logger.Debug($"[DASH] removed {_segs.Count - _deduped.Count} duplicate segment(s) in {streamSpec.GroupId}");
+                            streamSpec.Playlist.MediaParts[0].MediaSegments = _deduped;
                         }
                     }
 

--- a/src/N_m3u8DL-RE.Tests/Parser/Extractor/DASHExtractor2Tests.cs
+++ b/src/N_m3u8DL-RE.Tests/Parser/Extractor/DASHExtractor2Tests.cs
@@ -35,4 +35,24 @@ public class DASHExtractor2Tests
         first.Playlist.MediaInit.ShouldNotBeNull();
         first.Playlist.MediaInit.Url.ShouldBe("1/init.mp4");
     }
+
+    [Fact]
+    public async Task DASHExtractor2_RemovesDuplicateSegments()
+    {
+        // 该MPD含有一个重复引用的分片(seg-2.m4s 出现两次), 解析后应只保留一次 (#684)
+        const string mpdName = "Dash.Manifest_DuplicateSegments.mpd";
+        var config = CreateTestConfig(mpdName);
+        var content = ResourceHelper.Read(mpdName);
+        var extractor = new DASHExtractor2(config);
+        var results = await extractor.ExtractStreamsAsync(content);
+
+        results.ShouldNotBeNull();
+        results.Count.ShouldBe(1);
+
+        var segments = results.First().Playlist!.MediaParts[0].MediaSegments;
+        // 原始MPD有4个SegmentURL(seg-2重复), 去重后应为3个
+        segments.Count.ShouldBe(3);
+        // 顺序保持不变
+        segments.Select(s => s.Url).ShouldBe(new[] { "seg-1.m4s", "seg-2.m4s", "seg-3.m4s" });
+    }
 }

--- a/src/N_m3u8DL-RE.Tests/Resources/Dash/Manifest_DuplicateSegments.mpd
+++ b/src/N_m3u8DL-RE.Tests/Resources/Dash/Manifest_DuplicateSegments.mpd
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" type="static" mediaPresentationDuration="PT8S" minBufferTime="PT2S" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011">
+  <Period id="0">
+    <AdaptationSet contentType="video" mimeType="video/mp4">
+      <Representation id="video" bandwidth="500000" width="640" height="360" codecs="avc1.64001f">
+        <SegmentList timescale="1" duration="2">
+          <Initialization sourceURL="init.mp4"/>
+          <SegmentURL media="seg-1.m4s"/>
+          <SegmentURL media="seg-2.m4s"/>
+          <SegmentURL media="seg-2.m4s"/>
+          <SegmentURL media="seg-3.m4s"/>
+        </SegmentList>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>


### PR DESCRIPTION
### Problem

DASH manifests can reference the same media segment more than once — e.g. overlapping `Period`/`Representation` boundaries, repeated `SegmentTimeline` `<S>` entries, or DASH-IF Timing-Model [connectivity duplicates](https://dashif.org/Guidelines-TimingModel#connectivity-duplicates). When this happens, `DASHExtractor2` adds the same segment to the playlist twice, so N_m3u8DL-RE **downloads the overlapping segment twice** (reported in #684 with `https://gcp.prd.media.h264.io/.../3_db37ec.mpd`).

The parser previously built each Representation's segment list across the various `SegmentBase`/`SegmentList`/`SegmentTemplate(+SegmentTimeline)` forms **without de-duplicating**.

### Fix

After a Representation's segment list is built, drop exact duplicate segments, using **URL + byte range (`StartRange`/`ExpectLength`)** as the segment identity, preserving original order (`DASHExtractor2.cs`).

This is surgical and a pure correctness fix:
- Distinct byte ranges of the same URL stay separate (range is part of the key).
- `$Number$` / `$Time$`-templated URLs are already distinct, so normal timelines are untouched.
- Only exact duplicates are removed; if nothing is duplicated the list is left as-is (verified by the existing `DASHExtractor2_Normal` test, still 23 streams / 184 segments).
- Indexes stay monotonically increasing; everything downstream orders by `Index` (OrderBy/Min/Max), so dropping later duplicates keeps order consistent.
- Only a `Logger.Debug` line is emitted when something is actually removed.

### Test

Adds `Resources/Dash/Manifest_DuplicateSegments.mpd` (a `SegmentList` with `seg-2.m4s` referenced twice) and `DASHExtractor2_RemovesDuplicateSegments`, asserting the segment is kept only once (3 segments, order `seg-1, seg-2, seg-3`). All 36 tests pass.

Fixes #684

🤖 Generated with [Claude Code](https://claude.com/claude-code)