### PR TITLE
Add period= selector key for multi-Period DASH streams

### DIFF
--- a/src/N_m3u8DL-RE.Common/Resource/StaticText.cs
+++ b/src/N_m3u8DL-RE.Common/Resource/StaticText.cs
@@ -521,6 +521,7 @@ internal static class StaticText
                   "* channel=REGEX: 按音频声道数匹配 (如 6, 2)\r\n" +
                   "* range=REGEX: 按视频动态范围匹配 (如 SDR, HDR, PQ)\r\n" +
                   "* url=REGEX: 按分片URL匹配\r\n" +
+                  "* period=REGEX: 按 DASH Period id 匹配 (多Period MPD, 如广告/分段)\r\n" +
                   "* segsMin=number: 仅保留分片数 >= number 的流\r\n" +
                   "* segsMax=number: 仅保留分片数 <= number 的流\r\n" +
                   "* plistDurMin=hms: 仅保留时长 >= hms 的流 (如 1h20m30s, 90s)\r\n" +
@@ -540,7 +541,11 @@ internal static class StaticText
                   "# 选择码率在800Kbps至1Mbps之间的视频\r\n" +
                   "-sv bwMin=800:bwMax=1000\r\n" +
                   "# 去除分片数不超过2的字幕流 (如 trick-play/广告列表)\r\n" +
-                  "-ds segsMax=2:for=all --auto-select\r\n",
+                  "-ds segsMax=2:for=all --auto-select\r\n" +
+                  "# 仅保留主内容 Period (排除广告 Period)\r\n" +
+                  "-sv period=\"main\":for=best\r\n" +
+                  "# 去除广告 Period 的视频\r\n" +
+                  "-dv period=\"ad\":for=all\r\n",
             zhTW: "通過正則表達式選擇符合要求的影片軌. 你能夠以:分隔形式指定如下參數.\r\n" +
                   "同樣的參數也適用於 --select-audio/-sa, --select-subtitle/-ss 以及對應的 --drop-video/--drop-audio/--drop-subtitle 選項.\r\n\r\n" +
                   "* id=REGEX: 按 GroupId 匹配\r\n" +
@@ -552,6 +557,7 @@ internal static class StaticText
                   "* channel=REGEX: 按音訊聲道數匹配 (如 6, 2)\r\n" +
                   "* range=REGEX: 按影片動態範圍匹配 (如 SDR, HDR, PQ)\r\n" +
                   "* url=REGEX: 按分片URL匹配\r\n" +
+                  "* period=REGEX: 按 DASH Period id 匹配 (多Period MPD, 如廣告/分段)\r\n" +
                   "* segsMin=number: 僅保留分片數 >= number 的串流\r\n" +
                   "* segsMax=number: 僅保留分片數 <= number 的串流\r\n" +
                   "* plistDurMin=hms: 僅保留時長 >= hms 的串流 (如 1h20m30s, 90s)\r\n" +
@@ -571,7 +577,11 @@ internal static class StaticText
                   "# 選擇碼率在800Kbps至1Mbps之間的影片\r\n" +
                   "-sv bwMin=800:bwMax=1000\r\n" +
                   "# 去除分片數不超過2的字幕串流 (如 trick-play/廣告列表)\r\n" +
-                  "-ds segsMax=2:for=all --auto-select\r\n",
+                  "-ds segsMax=2:for=all --auto-select\r\n" +
+                  "# 僅保留主內容 Period (排除廣告 Period)\r\n" +
+                  "-sv period=\"main\":for=best\r\n" +
+                  "# 去除廣告 Period 的影片\r\n" +
+                  "-dv period=\"ad\":for=all\r\n",
             enUS: "Select video streams by regular expressions. OPTIONS is a colon (:) separated list of the following sub-keys.\r\n" +
                   "The same sub-keys also work for --select-audio/-sa, --select-subtitle/-ss and the matching --drop-video/--drop-audio/--drop-subtitle options.\r\n\r\n" +
                   "* id=REGEX: match by group/stream id\r\n" +
@@ -583,6 +593,7 @@ internal static class StaticText
                   "* channel=REGEX: match by audio channel count (e.g. 6, 2)\r\n" +
                   "* range=REGEX: match by video range (e.g. SDR, HDR, PQ)\r\n" +
                   "* url=REGEX: match by segment url\r\n" +
+                  "* period=REGEX: match by DASH Period id (multi-Period MPD, e.g. ads/chapters)\r\n" +
                   "* segsMin=number: keep streams with at least number segments\r\n" +
                   "* segsMax=number: keep streams with at most number segments\r\n" +
                   "* plistDurMin=hms: keep streams whose playlist duration >= hms (e.g. 1h20m30s, 90s)\r\n" +
@@ -602,7 +613,11 @@ internal static class StaticText
                   "# Select video with bandwidth between 800Kbps and 1Mbps\r\n" +
                   "-sv bwMin=800:bwMax=1000\r\n" +
                   "# Drop subtitle streams that have at most 2 segments (e.g. trick-play/ad playlists)\r\n" +
-                  "-ds segsMax=2:for=all --auto-select\r\n"
+                  "-ds segsMax=2:for=all --auto-select\r\n" +
+                  "# Keep only the main content Period (exclude ad Periods)\r\n" +
+                  "-sv period=\"main\":for=best\r\n" +
+                  "# Drop video from the ad Period\r\n" +
+                  "-dv period=\"ad\":for=all\r\n"
         ),
         ["cmd_selectAudio"] = new TextContainer
         (

--- a/src/N_m3u8DL-RE.Tests/Parser/Extractor/DASHPeriodSelectorTests.cs
+++ b/src/N_m3u8DL-RE.Tests/Parser/Extractor/DASHPeriodSelectorTests.cs
@@ -1,0 +1,88 @@
+using System.Text.RegularExpressions;
+using Shouldly;
+using N_m3u8DL_RE.Common.Entity;
+using N_m3u8DL_RE.Entity;
+using N_m3u8DL_RE.Parser.Config;
+using N_m3u8DL_RE.Parser.Extractor;
+using N_m3u8DL_RE.Util;
+
+namespace N_m3u8DL_RE.Tests.Parser.Extractor;
+
+public class DASHPeriodSelectorTests
+{
+    private static ParserConfig CreateTestConfig(string mpdFileName) => new ParserConfig
+    {
+        OriginalUrl = $"file:///fake/path/to/{mpdFileName}",
+    };
+
+    private static async Task<List<StreamSpec>> ExtractAsync(string mpdName)
+    {
+        var config = CreateTestConfig(mpdName);
+        var content = ResourceHelper.Read(mpdName);
+        var extractor = new DASHExtractor2(config);
+        return await extractor.ExtractStreamsAsync(content);
+    }
+
+    [Fact]
+    public async Task MultiPeriod_StreamsCarryPeriodId()
+    {
+        var results = await ExtractAsync("Dash.Manifest_MultiPeriod.mpd");
+
+        results.ShouldNotBeNull();
+        // ad-period: 1 video + 1 audio, main-period: 2 video + 1 audio
+        results.Count.ShouldBe(5);
+
+        results.Count(s => s.PeriodId == "ad-period").ShouldBe(2);
+        results.Count(s => s.PeriodId == "main-period").ShouldBe(3);
+        results.ShouldAllBe(s => s.PeriodId != null);
+    }
+
+    [Fact]
+    public async Task PeriodIdReg_KeepsOnlyMatchingPeriod()
+    {
+        var results = await ExtractAsync("Dash.Manifest_MultiPeriod.mpd");
+
+        var filter = new StreamFilter
+        {
+            PeriodIdReg = new Regex("main-period"),
+            For = "all",
+        };
+
+        var kept = FilterUtil.DoFilterKeep(results, filter);
+
+        kept.Count.ShouldBe(3);
+        kept.ShouldAllBe(s => s.PeriodId == "main-period");
+    }
+
+    [Fact]
+    public async Task PeriodIdReg_DropExcludesMatchingPeriod()
+    {
+        var results = await ExtractAsync("Dash.Manifest_MultiPeriod.mpd");
+
+        var filter = new StreamFilter
+        {
+            PeriodIdReg = new Regex("ad-period"),
+            For = "all",
+        };
+
+        var remaining = FilterUtil.DoFilterDrop(results, filter);
+
+        remaining.Count.ShouldBe(3);
+        remaining.ShouldAllBe(s => s.PeriodId == "main-period");
+    }
+
+    [Fact]
+    public async Task SinglePeriod_NotAffectedWhenNoPeriodFilter()
+    {
+        var results = await ExtractAsync("Dash.Manifest_1080p.mpd");
+
+        var filter = new StreamFilter
+        {
+            For = "all",
+        };
+
+        var kept = FilterUtil.DoFilterKeep(results, filter);
+
+        kept.Count.ShouldBe(results.Count);
+    }
+}

--- a/src/N_m3u8DL-RE.Tests/Resources/Dash/Manifest_MultiPeriod.mpd
+++ b/src/N_m3u8DL-RE.Tests/Resources/Dash/Manifest_MultiPeriod.mpd
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Synthetic multi-Period DASH manifest for unit tests.
+Entirely generic: uses example.com only. Two Periods (ad + main) with
+distinguishable Period id values and distinct segment URLs.
+-->
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" minBufferTime="PT1.500S" type="static" mediaPresentationDuration="PT0H0M40.000S" maxSegmentDuration="PT0H0M4.000S" profiles="urn:mpeg:dash:profile:isoff-live:2011">
+	<BaseURL>https://example.com/dash/</BaseURL>
+	<Period id="ad-period" duration="PT0H0M10.000S">
+		<BaseURL>ad/</BaseURL>
+		<AdaptationSet segmentAlignment="true" group="1" par="16:9" lang="und">
+			<Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+			<SegmentTemplate timescale="24" media="$RepresentationID$/$Number%04d$.m4s" startNumber="1" duration="96" initialization="$RepresentationID$/init.mp4" />
+			<Representation id="ad-v0" mimeType="video/mp4" codecs="avc1.64001f" width="640" height="360" frameRate="24" sar="1:1" startWithSAP="1" bandwidth="500000"></Representation>
+		</AdaptationSet>
+		<AdaptationSet segmentAlignment="true" group="2" lang="en">
+			<Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+			<SegmentTemplate timescale="24000" media="$RepresentationID$/$Number%04d$.m4s" startNumber="1" duration="95232" initialization="$RepresentationID$/init.mp4" />
+			<Representation id="ad-a0" mimeType="audio/mp4" codecs="mp4a.40.2" audioSamplingRate="48000" startWithSAP="1" bandwidth="128000">
+				<AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2" />
+			</Representation>
+		</AdaptationSet>
+	</Period>
+	<Period id="main-period" duration="PT0H0M30.000S">
+		<BaseURL>main/</BaseURL>
+		<AdaptationSet segmentAlignment="true" group="1" par="16:9" lang="und">
+			<Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+			<SegmentTemplate timescale="24" media="$RepresentationID$/$Number%04d$.m4s" startNumber="1" duration="96" initialization="$RepresentationID$/init.mp4" />
+			<Representation id="main-v0" mimeType="video/mp4" codecs="avc1.640028" width="1280" height="720" frameRate="24" sar="1:1" startWithSAP="1" bandwidth="2000000"></Representation>
+			<Representation id="main-v1" mimeType="video/mp4" codecs="avc1.640033" width="1920" height="1080" frameRate="24" sar="1:1" startWithSAP="1" bandwidth="4000000"></Representation>
+		</AdaptationSet>
+		<AdaptationSet segmentAlignment="true" group="2" lang="en">
+			<Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+			<SegmentTemplate timescale="24000" media="$RepresentationID$/$Number%04d$.m4s" startNumber="1" duration="95232" initialization="$RepresentationID$/init.mp4" />
+			<Representation id="main-a0" mimeType="audio/mp4" codecs="mp4a.40.2" audioSamplingRate="48000" startWithSAP="1" bandwidth="128000">
+				<AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2" />
+			</Representation>
+		</AdaptationSet>
+	</Period>
+</MPD>

--- a/src/N_m3u8DL-RE/CommandLine/CommandInvoker.cs
+++ b/src/N_m3u8DL-RE/CommandLine/CommandInvoker.cs
@@ -452,6 +452,10 @@ internal static partial class CommandInvoker
         if (!string.IsNullOrEmpty(url))
             streamFilter.UrlReg = new Regex(url);
 
+        var period = p.GetValue("period");
+        if (!string.IsNullOrEmpty(period))
+            streamFilter.PeriodIdReg = new Regex(period);
+
         var segsMin = p.GetValue("segsMin");
         if (!string.IsNullOrEmpty(segsMin))
             streamFilter.SegmentsMinCount = long.Parse(segsMin);

--- a/src/N_m3u8DL-RE/Entity/StreamFilter.cs
+++ b/src/N_m3u8DL-RE/Entity/StreamFilter.cs
@@ -15,6 +15,7 @@ public class StreamFilter
     public Regex? ChannelsReg { get; set; }
     public Regex? VideoRangeReg { get; set; }
     public Regex? UrlReg { get; set; }
+    public Regex? PeriodIdReg { get; set; }
     public long? SegmentsMinCount { get; set; }
     public long? SegmentsMaxCount { get; set; }
     public double? PlaylistMinDur {  get; set; }
@@ -38,6 +39,7 @@ public class StreamFilter
         if (ChannelsReg != null) sb.Append($"ChannelsReg: {ChannelsReg} ");
         if (VideoRangeReg != null) sb.Append($"VideoRangeReg: {VideoRangeReg} ");
         if (UrlReg != null) sb.Append($"UrlReg: {UrlReg} ");
+        if (PeriodIdReg != null) sb.Append($"PeriodIdReg: {PeriodIdReg} ");
         if (SegmentsMinCount != null) sb.Append($"SegmentsMinCount: {SegmentsMinCount} ");
         if (SegmentsMaxCount != null) sb.Append($"SegmentsMaxCount: {SegmentsMaxCount} ");
         if (PlaylistMinDur != null) sb.Append($"PlaylistMinDur: {PlaylistMinDur} ");

--- a/src/N_m3u8DL-RE/Util/FilterUtil.cs
+++ b/src/N_m3u8DL-RE/Util/FilterUtil.cs
@@ -33,6 +33,8 @@ public static class FilterUtil
             inputs = inputs.Where(i => i.VideoRange != null && filter.VideoRangeReg.IsMatch(i.VideoRange));
         if (filter.UrlReg != null)
             inputs = inputs.Where(i => i.Url != null && filter.UrlReg.IsMatch(i.Url));
+        if (filter.PeriodIdReg != null)
+            inputs = inputs.Where(i => i.PeriodId != null && filter.PeriodIdReg.IsMatch(i.PeriodId));
         if (filter.SegmentsMaxCount != null && inputs.All(i => i.SegmentsCount > 0)) 
             inputs = inputs.Where(i => i.SegmentsCount < filter.SegmentsMaxCount);
         if (filter.SegmentsMinCount != null && inputs.All(i => i.SegmentsCount > 0))


### PR DESCRIPTION
## What

Adds a first-class `period=<regex>` sub-key to the stream selectors so multi-Period DASH manifests can be selected or dropped by Period.

Multi-Period MPDs (ad pre/mid-rolls, bumpers, codec or resolution splits, chaptered content) currently can't be targeted by Period. Users have to hand-edit the MPD or rely on brittle `url=`/`id=` regexes that only happen to differ per Period. This adds a proper key, matching the existing selector ergonomics.

## How

`StreamSpec.PeriodId` is **already** populated by the DASH parser, so this change is small and additive — it only wires that existing field into the filter pipeline:

- `StreamFilter.PeriodIdReg` (+ reflected in `ToString()`)
- `ParseStreamFilter` reads the `period` key into `PeriodIdReg`, mirroring the sibling keys (`id=`, `url=`, `lang=`, ...)
- `FilterUtil.DoFilterKeep` keeps streams whose `PeriodId` matches
- Help text (`cmd_selectVideo_more`, zh-CN / zh-TW / en-US) documents `period=` with examples

Because the drop selectors (`-dv`/`-da`/`-ds`) share the same `StreamFilter` pipeline as `-sv`/`-sa`/`-ss`, the key works for both keep and drop for free.

## Behavior

Purely additive. With no `period=` key present, behavior is identical to before — no new logs, no new modes.

Examples:

```
# keep only the main content Period (exclude ad Periods)
-sv period="main":for=best
# drop video from the ad Period
-dv period="ad":for=all
```

## Tests

Adds a synthetic, fully generic two-Period MPD fixture (`example.com`, an `ad-period` and a `main-period` with distinct ids and segment paths) plus unit tests asserting:

- streams carry the expected `PeriodId` after extraction
- `DoFilterKeep` with `PeriodIdReg` keeps only the matching Period's streams
- `DoFilterDrop` excludes the matching Period
- a normal single-Period manifest is unaffected when no `period=` key is used

All tests pass; existing tests stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)