### PR TITLE
Fix: cache AES-128 key per URL to prevent repeated HTTP requests

### DIFF
--- a/src/N_m3u8DL-RE.Parser/Processor/HLS/DefaultHLSKeyProcessor.cs
+++ b/src/N_m3u8DL-RE.Parser/Processor/HLS/DefaultHLSKeyProcessor.cs
@@ -11,6 +11,9 @@ namespace N_m3u8DL_RE.Parser.Processor.HLS;
 
 public class DefaultHLSKeyProcessor : KeyProcessor
 {
+    private static readonly Dictionary<string, byte[]> KeyCache = new();
+    private static readonly object KeyCacheLock = new();
+
     public override bool CanProcess(ExtractorType extractorType, string m3u8Url, string keyLine, string m3u8Content, ParserConfig paserConfig) => extractorType == ExtractorType.HLS;
 
 
@@ -60,12 +63,25 @@ public class DefaultHLSKeyProcessor : KeyProcessor
             }
             else if (!string.IsNullOrEmpty(uri))
             {
-                var retryCount = parserConfig.KeyRetryCount;
                 var segUrl = PreProcessUrl(ParserUtil.CombineURL(m3u8Url, uri), parserConfig);
+                lock (KeyCacheLock)
+                {
+                    if (KeyCache.TryGetValue(segUrl, out var cachedKey))
+                    {
+                        encryptInfo.Key = cachedKey;
+                        goto keyDone;
+                    }
+                }
+
+                var retryCount = parserConfig.KeyRetryCount;
                 getHttpKey:
                 try
                 {
                     var bytes = HTTPUtil.GetBytesAsync(segUrl, parserConfig.Headers).Result;
+                    lock (KeyCacheLock)
+                    {
+                        KeyCache[segUrl] = bytes;
+                    }
                     encryptInfo.Key = bytes;
                 }
                 catch (Exception _ex) when (!_ex.Message.Contains("scheme is not supported."))
@@ -76,6 +92,7 @@ public class DefaultHLSKeyProcessor : KeyProcessor
                     throw;
                 }
             }
+            keyDone:;
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Problem

When an HLS playlist has per-segment \#EXT-X-KEY\ tags with varying IV values (but the same key URI), \ParseKey()\ in \HLSExtractor.ParseListAsync\ is called for each unique key line. Each call triggers \DefaultHLSKeyProcessor.Process()\ which makes a new HTTP request to fetch the same \es128.key\.

For videos with thousands of segments, this causes:
- Thousands of identical HTTP requests to the same key URL
- Effectively deadlocking the download (5229 segments × ~130ms/request ≈ 11 minutes of key fetching)

## Fix

Added a static \KeyCache\ dictionary in \DefaultHLSKeyProcessor\ to cache fetched key bytes by URL. Same key URL only triggers one HTTP request.

## Verification

Tested with a real CloudFront HLS stream (5229 segments, AES-128 encrypted). Before fix: stuck in infinite key fetch loop. After fix: key fetched once, download proceeds normally.

Closes #932